### PR TITLE
Add filter for admin and sending out of email

### DIFF
--- a/apps/accounts/forms.py
+++ b/apps/accounts/forms.py
@@ -21,7 +21,10 @@ class CustomUserChangeForm(UserChangeForm):
 
 class HostingAdminForm(forms.ModelForm):
     email_template = forms.ChoiceField(
-        choices=[('info.txt', 'I need more information'), ('mu', 'mu')],
+        choices=[
+            ('additional-info.txt', 'I need more information'),
+            ('pending-removal.txt', 'Pending removal')
+        ],
         required=False,
         label='email'
     )

--- a/apps/accounts/templates/emails/additional-info.txt
+++ b/apps/accounts/templates/emails/additional-info.txt
@@ -1,6 +1,6 @@
 Dear hoster,
 
-On {{ user.date_joined }} you registered {{ host.name }} at the Green Web Directory [1]. Since it is not directly clear to us why and how you are green hosted, we kindly ask you to provide us with the following additional information:
+{% if user.date_joined %}On {{ user.date_joined }}{% else %}Some time in the past{% endif %} you registered {{ host.name }} at the Green Web Directory [1]. Since it is not directly clear to us why and how you are green hosted, we kindly ask you to provide us with the following additional information:
 
 Could you refer us to your corporate social responsibility page, or a comparable page where you explain how you have approached to become a green hoster or website?
 

--- a/apps/accounts/templates/emails/additional-info.txt
+++ b/apps/accounts/templates/emails/additional-info.txt
@@ -1,0 +1,14 @@
+Dear hoster,
+
+On {{ user.date_joined }} you registered {{ host.name }} at the Green Web Directory [1]. Since it is not directly clear to us why and how you are green hosted, we kindly ask you to provide us with the following additional information:
+
+Could you refer us to your corporate social responsibility page, or a comparable page where you explain how you have approached to become a green hoster or website?
+
+Is it possible to refer us to a valid certificate awarded to yourself or the company that provides your digital infrastructure to you?
+
+Thanks for your help in keeping the Green Web Directory up-to-date! We’re experiencing significant growth in the number of checks against the database, currently over 7 million per day and counting, so it does make sense!
+
+With best regards,
+The Green Web Foundation Support Team
+
+[1] https://www.thegreenwebfoundation.org/

--- a/apps/accounts/templates/emails/info.txt
+++ b/apps/accounts/templates/emails/info.txt
@@ -1,1 +1,0 @@
-Test email

--- a/apps/accounts/templates/emails/pending-removal.txt
+++ b/apps/accounts/templates/emails/pending-removal.txt
@@ -1,6 +1,6 @@
 Dear hoster,
 
-On {{ user.date_joined }} you registered {{ host.name }} at the Green Web Directory [1]. A recent check discovered that your website ({{ host.website }}) no longer turns up as green when checked against the green credentials available in our system for your company.
+{% if user.date_joined %}On {{ user.date_joined }}{% else %}Some time in the past{% endif %} you registered {{ host.name }} at the Green Web Directory [1]. A recent check discovered that your website ({{ host.website }}) no longer turns up as green when checked against the green credentials available in our system for your company.
 
 For now, we have placed {{ host.name }} on the list of green hosters that need to update their ASN or ip-ranges in the admin system [2]. After approval, the website will be visible in the Green Web Directory again.
 

--- a/apps/accounts/templates/emails/pending-removal.txt
+++ b/apps/accounts/templates/emails/pending-removal.txt
@@ -1,0 +1,13 @@
+Dear hoster,
+
+On {{ user.date_joined }} you registered {{ host.name }} at the Green Web Directory [1]. A recent check discovered that your website ({{ host.website }}) no longer turns up as green when checked against the green credentials available in our system for your company.
+
+For now, we have placed {{ host.name }} on the list of green hosters that need to update their ASN or ip-ranges in the admin system [2]. After approval, the website will be visible in the Green Web Directory again.
+
+Thanks for your help in keeping the Green Web Directory up-to-date! We’re experiencing significant growth in the number of checks against the database, currently over 7 million per day and counting, so it does make sense!
+
+With best regards,
+The Green Web Foundation Support Team
+
+[1] https://www.thegreenwebfoundation.org/
+[2] https://admin.thegreenwebfoundation.org/


### PR DESCRIPTION
This adds a way to filter for hosts that are shown on the website in admin plus it lets you order by how many ip ranges are registered. (There are several hosts that have 0 ip ranges). 

I've also added the emails that Rene wrote up. 

- [x] Check that emails look ok in console before merging.  