### PR TITLE
Add listview for approvals

### DIFF
--- a/apps/accounts/management/commands/migrate_approvals_idorig_to_null.py
+++ b/apps/accounts/management/commands/migrate_approvals_idorig_to_null.py
@@ -1,0 +1,22 @@
+from django.core.management.base import BaseCommand
+from django.db import connection
+
+
+class Command(BaseCommand):
+    help = "Migrating 0 to null for ip approvals"
+
+    def handle(self, *args, **options):
+        with connection.cursor() as cursor:
+            cursor.execute('''
+                UPDATE greencheck_ip_approve
+                SET idorig = NULL
+                WHERE idorig = 0
+            ''')
+
+            cursor.execute('''
+                UPDATE greencheck_as_approve
+                SET idorig = NULL
+                WHERE idorig = 0
+            ''')
+
+        self.stdout.write(self.style.SUCCESS('Migrated 0 to be NULL!'))

--- a/apps/greencheck/models.py
+++ b/apps/greencheck/models.py
@@ -68,6 +68,9 @@ class IpAddressField(models.DecimalField):
 
     def get_prep_value(self, value):
         if value is not None:
+            if isinstance(value, str):
+                value = ipaddress.ip_address(value)
+
             return decimal.Decimal(int(value))
         return None
 


### PR DESCRIPTION
Gets you a list view for both ip and asn approvals so you can find the approvals easier. Part of this, is that we need to run a migration to replace 0 with null. If we don't do this, it will bark when you save an approval. 