### PR TITLE
Change the logout template to include copy and image

### DIFF
--- a/apps/accounts/admin_site.py
+++ b/apps/accounts/admin_site.py
@@ -10,6 +10,7 @@ class GreenWebAdmin(AdminSite):
     site_header = 'Green Web Admin'
     index_title = ''
     login_template = 'login.html'
+    logout_template = 'logout.html'
 
     def has_permission(self, request):
         """

--- a/apps/accounts/templates/logout.html
+++ b/apps/accounts/templates/logout.html
@@ -1,0 +1,18 @@
+{% extends "admin/base_site.html" %}
+{% load i18n static %}
+
+{% block breadcrumbs %}<div class="breadcrumbs"><a href="{% url 'admin:index' %}">{% trans 'Home' %}</a></div>{% endblock %}
+
+{% block content_title %}{% endblock %}
+
+{% block content %}
+<div style="margin: auto auto; width: 80%; text-align:center;">
+    <a href="https://www.thegreenwebfoundation.org/partner-up/">
+        <img src="{% static "accounts/images/partner.png" %}" alt="Partner up with us!" style="max-width: 600px; margin: 0 auto; text-align: center;display: inline-block; width: 100%;">
+    </a>
+
+    <p>{% trans "Thanks for spending some quality time with the Green web foundation today." %}</p>
+
+    <p><a href="{% url 'admin:index' %}">{% trans 'Log in again' %}</a></p>
+</div>
+{% endblock %}


### PR DESCRIPTION
This allows us to modify the template when a user logs out. Rene wished that we displayed the banner when someone logged out, and that we customized the message to say that we thanked them for spending time at the green web foundation web site. 