### PR TITLE
Comment out hosting communication for the time being

### DIFF
--- a/apps/accounts/admin.py
+++ b/apps/accounts/admin.py
@@ -214,10 +214,11 @@ class HostingAdmin(admin.ModelAdmin):
             'Email sent to user'
         )
 
-        HostingCommunication.objects.create(
-            template=email_template,
-            hostingprovider=obj
-        )
+        # This table is unusable right now.
+        # HostingCommunication.objects.create(
+        #     template=email_template,
+        #     hostingprovider=obj
+        # )
 
         name = 'admin:' + get_admin_name(self.model, 'change')
         return redirect(name, obj.pk)


### PR DESCRIPTION
Because we couldn't migrate the table properly, we can't use the logging functionality for communication right now. 

See the following issue that tracks this more closely: https://github.com/thegreenwebfoundation/thegreenwebfoundation/issues/39