### PR TITLE
WIP - Update data cleaning scripts

### DIFF
--- a/ansible/deploy.yml
+++ b/ansible/deploy.yml
@@ -32,10 +32,7 @@
       DATABASE_URL: "{{ database_url }}"
       SECRET_KEY: "{{ secret_key }}"
       DJANGO_SETTINGS_MODULE: "{{ django_settings_module }}"
-
-    project_shared_children:
-      - path: "/log"
-        src: "logs"
+      GOOGLE_APPLICATION_CREDENTIALS: "{{ google_application_credentials }}"
 
     project_unwanted_items:
       - .git

--- a/ansible/inventories/prod
+++ b/ansible/inventories/prod
@@ -1,2 +1,2 @@
 [prod]
-thegreenwebfoundation.org project_root="/var/www/{{ tgwf_domain_name }}.thegreenwebfoundation.org" tgwf_stage="prod" tgwf_domain_name=newadmin gunicorn_port=9002
+thegreenwebfoundation.org project_root="/var/www/{{ tgwf_domain_name }}.thegreenwebfoundation.org" tgwf_stage="prod" tgwf_domain_name=admin gunicorn_port=9002

--- a/ansible/inventories/staging
+++ b/ansible/inventories/staging
@@ -1,2 +1,2 @@
 [staging]
-thegreenwebfoundation.org tgwf_stage="staging" tgwf_domain_name=staging-newadmin project_root="/var/www/{{ tgwf_domain_name }}.thegreenwebfoundation.org" gunicorn_port=9003
+thegreenwebfoundation.org tgwf_stage="staging" tgwf_domain_name=staging-admin project_root="/var/www/{{ tgwf_domain_name }}.thegreenwebfoundation.org" gunicorn_port=9003

--- a/apps/greencheck/management/commands/insert_procedures.py
+++ b/apps/greencheck/management/commands/insert_procedures.py
@@ -13,7 +13,7 @@ class Command(BaseCommand):
             presenting_table = render_to_string('presenting.sql')
 
             # add stored procedures to work by url, working backwards from
-            # latest checks, rather than working forwards the earliest checks
+            # latest checks, rather than working forwards from the earliest checks
             add_latest_check_for_url = render_to_string('add_latest_check_for_url_procedure.sql')
             backfill_by_url = render_to_string('backfill_by_url_procedure.sql')
 

--- a/apps/greencheck/management/commands/insert_procedures.py
+++ b/apps/greencheck/management/commands/insert_procedures.py
@@ -12,6 +12,11 @@ class Command(BaseCommand):
             backfill = render_to_string('backfill_procedure.sql')
             presenting_table = render_to_string('presenting.sql')
 
+            # add stored procedures to work by url, working backwards from
+            # latest checks, rather than working forwards the earliest checks
+            add_latest_check_for_url = render_to_string('add_latest_check_for_url_procedure.sql')
+            backfill_by_url = render_to_string('backfill_by_url_procedure.sql')
+
             cursor.execute(presenting_table)
             cursor.execute(insert_urls)
             cursor.execute(backfill)

--- a/apps/greencheck/templates/add_latest_check_for_url_procedure.sql
+++ b/apps/greencheck/templates/add_latest_check_for_url_procedure.sql
@@ -22,6 +22,17 @@ BEGIN
   DECLARE h_hostpartner     VARCHAR(255);
   DECLARE h_hostwebsite     VARCHAR(255);
 
+
+  -- SELECT concat('** checking for: ', purl) AS '** DEBUG:';
+
+  DECLARE CONTINUE HANDLER FOR NOT FOUND
+    BEGIN
+      -- SELECT concat('** NO RESULT FOR: ', purl) AS '** DEBUG:';
+      -- SELECT concat('** BUT WE SHOULD NOT BUBBLE THE EXCEPTION UP: ', '') AS '** DEBUG:';
+    END;
+
+
+
   -- fetch the latest result for this url, using the index
   SELECT id, id_hp, id_greencheck, type, url, ip, datum, green, tld
   FROM greencheck
@@ -38,6 +49,8 @@ BEGIN
 
     -- check
     IF g_green = 'yes' THEN
+
+      -- SELECT concat('** GREEN: ', purl) AS '** DEBUG:';
       INSERT INTO green_presenting
       (
         `id`,

--- a/apps/greencheck/templates/add_latest_check_for_url_procedure.sql
+++ b/apps/greencheck/templates/add_latest_check_for_url_procedure.sql
@@ -50,6 +50,7 @@ BEGIN
     -- check
     IF g_green = 'yes' THEN
 
+      START TRANSACTION;
       -- SELECT concat('** GREEN: ', purl) AS '** DEBUG:';
       INSERT INTO green_presenting
       (
@@ -73,5 +74,8 @@ BEGIN
         `hosted_by_id` = g_id_hp,
         `hosted_by_website` = h_hostwebsite,
         `partner` = h_hostpartner;
+
+      COMMIT;
+
     END IF;
 END

--- a/apps/greencheck/templates/add_latest_check_for_url_procedure.sql
+++ b/apps/greencheck/templates/add_latest_check_for_url_procedure.sql
@@ -1,0 +1,64 @@
+DROP PROCEDURE IF EXISTS add_latest_check_for_url;
+
+-- define our procedure, that accepts the url param, as a VarChar
+CREATE PROCEDURE add_latest_check_for_url(IN purl VarChar(255))
+
+BEGIN
+
+
+  -- declare the types we'd fetch from the cursor
+  DECLARE g_id            BIGINT(20);
+  DECLARE g_id_hp         INT(11);
+  DECLARE g_id_greencheck INT(11);
+  DECLARE g_type          ENUM('url','whois','ip','none','as');
+  DECLARE g_url           VARCHAR(255);
+  DECLARE g_ip            DECIMAL(39,0);
+  DECLARE g_datum         TIMESTAMP;
+  DECLARE g_green         ENUM('yes','no','old');
+  DECLARE g_tld           VARCHAR(64);
+
+  -- declare the other types for the next query
+  DECLARE h_hostname        VARCHAR(255);
+  DECLARE h_hostpartner     VARCHAR(255);
+  DECLARE h_hostwebsite     VARCHAR(255);
+
+  -- fetch the latest result for this url, using the index
+  SELECT id, id_hp, id_greencheck, type, url, ip, datum, green, tld
+  FROM greencheck
+  WHERE url = purl
+  ORDER BY datum
+  LIMIT 1
+  INTO g_id, g_id_hp, g_id_greencheck, g_type, g_url, g_ip, g_datum, g_green, g_tld;
+
+
+   -- now get our hosting providers
+
+  SELECT naam, partner, website INTO h_hostname, h_hostpartner, h_hostwebsite
+  FROM hostingproviders WHERE id = g_id_hp;
+
+    -- check
+    IF g_green = 'yes' THEN
+      INSERT INTO green_presenting
+      (
+        `id`,
+        `modified`, `green`, `hosted_by`,
+        `hosted_by_id`, `hosted_by_website`,
+        `partner`, `url`
+      )
+      VALUES (
+        g_id,
+        g_datum, 1, h_hostname,
+        g_id_hp, h_hostwebsite,
+        h_hostpartner, g_url
+      )
+      -- we need an upsert
+      ON DUPLICATE KEY UPDATE
+        `id` = g_id,
+        `modified` = g_datum,
+        `green` = g_green,
+        `hosted_by` = h_hostname,
+        `hosted_by_id` = g_id_hp,
+        `hosted_by_website` = h_hostwebsite,
+        `partner` = h_hostpartner;
+    END IF;
+END

--- a/apps/greencheck/templates/backfill_by_url_procedure.sql
+++ b/apps/greencheck/templates/backfill_by_url_procedure.sql
@@ -31,12 +31,13 @@ BEGIN
 
     CALL add_latest_check_for_url(fetched_url);
 
+
     SET counter = counter + 1;
 
     -- counter added to show progress
-    -- IF mod(counter, 100) = 0 THEN
-    --   SELECT concat('** progress ', counter) AS '** DEBUG:';
-    -- END IF;
+    IF mod(counter, 100000) = 0 THEN
+      SELECT concat('** progress ', counter) AS '** DEBUG:';
+    END IF;
 
 
     IF DONE THEN

--- a/apps/greencheck/templates/backfill_by_url_procedure.sql
+++ b/apps/greencheck/templates/backfill_by_url_procedure.sql
@@ -1,0 +1,34 @@
+
+-- then for each url, we run a query to get the latest result from
+-- greencheck using the date index, and if it is green
+-- load that into the green_presenting table
+
+DROP PROCEDURE IF EXISTS backfill_by_url;
+
+CREATE PROCEDURE backfill_by_url()
+
+BEGIN
+  -- we need a way to check so we can exit the loop
+  DECLARE done INT(1) DEFAULT FALSE;
+
+  -- declare the types we'd fetch from the cursor
+  DECLARE url                VARCHAR(255);
+
+  -- set up our cursor, so we have a list of urls to loop through
+  DECLARE cur CURSOR FOR
+  SELECT url FROM green_presenting;
+
+  -- set the end state: handle the not found case by setting done to true
+  DECLARE CONTINUE HANDLER FOR NOT FOUND SET done = TRUE;
+
+  -- open our cursor to start listing through all the urls
+  OPEN cur;
+
+  REPEAT
+    FETCH cur INTO url;
+    CALL add_latest_check_for_url(url);
+
+  UNTIL done END REPEAT;
+
+  CLOSE cur;
+END;

--- a/apps/greencheck/templates/load_in_csv.sql
+++ b/apps/greencheck/templates/load_in_csv.sql
@@ -1,13 +1,14 @@
+-- a temporary table to facilitate the creation of the green urls table
 CREATE TABLE urls (
   url VARCHAR(255),
   PRIMARY KEY (url)
 );
 
-LOAD DATA
-  INFILE 'all_domains_outfile.txt'
-INTO TABLE
-  urls
-FIELDS TERMINATED BY ','
-ENCLOSED BY ''
-LINES TERMINATED BY '\n'
-IGNORE 1 ROWS;
+-- LOAD DATA
+--   INFILE 'all_domains_outfile.txt'
+-- INTO TABLE
+--   urls
+-- FIELDS TERMINATED BY ','
+-- ENCLOSED BY ''
+-- LINES TERMINATED BY '\n'
+-- IGNORE 1 ROWS;

--- a/apps/greencheck/templates/load_in_csv.sql
+++ b/apps/greencheck/templates/load_in_csv.sql
@@ -1,0 +1,13 @@
+CREATE TABLE urls (
+  url VARCHAR(255),
+  PRIMARY KEY (url)
+);
+
+LOAD DATA
+  INFILE 'all_domains_outfile.txt'
+INTO TABLE
+  urls
+FIELDS TERMINATED BY ','
+ENCLOSED BY ''
+LINES TERMINATED BY '\n'
+IGNORE 1 ROWS;

--- a/apps/greencheck/url2green.py
+++ b/apps/greencheck/url2green.py
@@ -1,0 +1,45 @@
+import csv
+import re
+
+
+# these files are large, and we need to read from one file,
+# and only write the lines that count as real hostnames
+# we can check the host
+
+
+def lazy_messy_url_list(path_to_infile):
+    """
+    Accept a text file at `path`, with one url per line,
+    and return an generator to iterate through each line
+    """
+    with open(path, "r") as messy_list_of_urls:
+        for line in messy_list_of_urls.readlines():
+            yield line
+
+
+def write_clean_urls(lazy_url_list, path_to_outfile):
+    """
+    Accept `lazy_url_list`, a iterable list of urls and
+    write the valid urls to the file `path_to_outfile`
+    """
+    with open(path_to_outfile, "w") as clean_url_list:
+        for url in lazy_url_iterator:
+            if is_valid_hostname(url):
+                clean_url_list.write(url)
+
+def is_valid_hostname(hostname):
+    """
+    Check that hostname passed in is valid.
+    Pretty much a copy paste of this
+    https://stackoverflow.com/questions/2532053/validate-a-hostname-string
+    """
+    if len(hostname) > 255:
+        return False
+    if hostname[-1] == ".":
+        hostname = hostname[:-1] # strip exactly one dot from the right, if present
+    allowed = re.compile("(?!-)[A-Z\d-]{1,63}(?<!-)$", re.IGNORECASE)
+    return all(allowed.match(x) for x in hostname.split("."))
+
+# Usage
+# urls = lazy_messy_url_list("path/to/file")
+# write_clean_urls(urls)


### PR DESCRIPTION
This PR adds a slightly different approach for backfilling the data into the green urls data, in the `green_presenting` table.

This consists of

- a new stored procedure, `add_latest_check_for_url` to add the latest result for a given url from the `greencheck` table. This looks for the latest check in backwards, rather than going through all urls, over the last N years until we find the latest check. Save work with a transaction when we _do_ find a url, so we can resume if need be. 
- second stored procedure, `backfill_by_url` to loop through a set of urls in a table, using this new `add_latest_check_for_url` procedure
- some python functions for cleaning a list distinct urls we might get from the main greencheck table, to strip out invalid hostnames - I used this when checking different sets of urls. About 23k out 20million urls were badly formed, and they caused the backfill procedures to choke.

