### PR TITLE
Inherit from field instead of DecimalField

### DIFF
--- a/apps/accounts/admin.py
+++ b/apps/accounts/admin.py
@@ -220,11 +220,10 @@ class HostingAdmin(admin.ModelAdmin):
             'Email sent to user'
         )
 
-        # This table is unusable right now.
-        # HostingCommunication.objects.create(
-        #     template=email_template,
-        #     hostingprovider=obj
-        # )
+        HostingCommunication.objects.create(
+            template=email_template,
+            hostingprovider=obj
+        )
 
         name = 'admin:' + get_admin_name(self.model, 'change')
         return redirect(name, obj.pk)


### PR DESCRIPTION
The underlying issue was that when admin rendered the field. We had the following function being executed. 

```
def display_for_field(value, field, empty_value_display):
    from django.contrib.admin.templatetags.admin_list import _boolean_icon

    if getattr(field, 'flatchoices', None):
        return dict(field.flatchoices).get(value, empty_value_display)
    # BooleanField needs special-case null-handling, so it comes before the
    # general null test.
    elif isinstance(field, models.BooleanField):
        return _boolean_icon(value)
    elif value is None:
        return empty_value_display
    elif isinstance(field, models.DateTimeField):
        return formats.localize(timezone.template_localtime(value))
    elif isinstance(field, (models.DateField, models.TimeField)):
        return formats.localize(value)
    elif isinstance(field, models.DecimalField):
        return formats.number_format(value, field.decimal_places)
    elif isinstance(field, (models.IntegerField, models.FloatField)):
        return formats.number_format(value)
    elif isinstance(field, models.FileField) and value:
        return format_html('<a href="{}">{}</a>', value.url, value)
    else:
        return display_for_value(value, empty_value_display)
```

Since IpAddress inherited from DecimalField we stumbled upon this issue. It would be great if you can test this before merging this in. 

What I've tested. In a created hostingprovider, I've successfully created a new IP without any error. 

Fixes #51 