### PR TITLE
Approved should be set by default

### DIFF
--- a/apps/accounts/migrations/0001_initial.py
+++ b/apps/accounts/migrations/0001_initial.py
@@ -30,6 +30,7 @@ class Migration(migrations.Migration):
             ],
             options={
                 'db_table': 'hostingproviders',
+                'verbose_name': 'Hosting Provider'
             },
         ),
         migrations.CreateModel(
@@ -103,7 +104,7 @@ class Migration(migrations.Migration):
             name='HostingproviderDatacenter',
             fields=[
                 ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
-                ('approved', models.BooleanField()),
+                ('approved', models.BooleanField(default=False)),
                 ('approved_at', models.DateTimeField(null=True)),
                 ('created_at', models.DateTimeField(auto_now_add=True)),
                 ('datacenter', models.ForeignKey(null=True, on_delete=django.db.models.deletion.CASCADE, to='accounts.Datacenter')),

--- a/apps/accounts/models/hosting.py
+++ b/apps/accounts/models/hosting.py
@@ -125,7 +125,7 @@ class HostingCommunication(TimeStampedModel):
 
 class HostingproviderDatacenter(models.Model):
     '''Intermediary table between Datacenter and Hostingprovider'''
-    approved = models.BooleanField()
+    approved = models.BooleanField(default=False)
     approved_at = models.DateTimeField(null=True)
     created_at = models.DateTimeField(auto_now_add=True)
     datacenter = models.ForeignKey(Datacenter, null=True, on_delete=models.CASCADE)


### PR DESCRIPTION
An error was recently triggered -> https://sentry.io/organizations/product-science/issues/1501302817/?project=2071451&referrer=alert_email

Approved should be set by default here. I checked that the migration did not create any database changes by doing sqlmigrate. 

So there we can make these changes in the initial migration to avoid migration bloat. 