### PR TITLE
Add importer for publicly listed IP addresses for AWS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,12 @@
 language: python
 python:
-  - "3.6"      # current default Python on Travis CI
+  - "3.6"
 
-# command to install dependencies
 install:
   - pip install pipenv --upgrade-strategy=only-if-needed
   - pipenv install --dev
 # command to run tests
 script:
   - pytest
+services:
+    - mysql

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: python
+python:
+  - "3.6"      # current default Python on Travis CI
+
+# command to install dependencies
+install:
+  - pip install pipenv --upgrade-strategy=only-if-needed
+  - pipenv install --dev
+# command to run tests
+script:
+  - pytest

--- a/Pipfile
+++ b/Pipfile
@@ -13,6 +13,9 @@ ipython = "*"
 ipdb = "*"
 mycli = "*"
 werkzeug = "*"
+pytest = "*"
+pytest-django = "*"
+pytest-watch = "*"
 
 [packages]
 # psycopg2-binary = "*", not needed for now.
@@ -23,16 +26,16 @@ django-countries = "==5.5"
 django-environ = "==0.4.5"
 django-extensions = "==2.2.5"
 django-model-utils = "==3.2.0"
-django-mysql = "==3.2.0"
+django-mysql = "*"
 django-registration = "==3.0.1"
 django-unixdatetimefield = "==1.0.3"
 gunicorn = "==19.9.0"
 mysqlclient = "==1.4.4"
 requests = "==2.22.0"
 whitenoise = {extras = ["brotli"],version = "==4.1.4"}
-db-to-sqlite = "==1.0.2"
-sqlite-utils = "==1.12.1"
-google-cloud-storage = "==1.23.0"
+db-to-sqlite = "*"
+sqlite-utils = "*"
+google-cloud-storage = "*"
 sentry-sdk = "*"
 
 [requires]

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "cc748a0b9eced4bcc987d6805ae3fc79576b7aa9d997ac58a9b93fe705f7f3e4"
+            "sha256": "76bfe413af4d8805feeda7e0bda01a254fa70f4eac7431908214217379c82322"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -93,41 +93,36 @@
         },
         "cffi": {
             "hashes": [
-                "sha256:0b49274afc941c626b605fb59b59c3485c17dc776dc3cc7cc14aca74cc19cc42",
-                "sha256:0e3ea92942cb1168e38c05c1d56b0527ce31f1a370f6117f1d490b8dcd6b3a04",
-                "sha256:135f69aecbf4517d5b3d6429207b2dff49c876be724ac0c8bf8e1ea99df3d7e5",
-                "sha256:19db0cdd6e516f13329cba4903368bff9bb5a9331d3410b1b448daaadc495e54",
-                "sha256:2781e9ad0e9d47173c0093321bb5435a9dfae0ed6a762aabafa13108f5f7b2ba",
-                "sha256:291f7c42e21d72144bb1c1b2e825ec60f46d0a7468f5346841860454c7aa8f57",
-                "sha256:2c5e309ec482556397cb21ede0350c5e82f0eb2621de04b2633588d118da4396",
-                "sha256:2e9c80a8c3344a92cb04661115898a9129c074f7ab82011ef4b612f645939f12",
-                "sha256:32a262e2b90ffcfdd97c7a5e24a6012a43c61f1f5a57789ad80af1d26c6acd97",
-                "sha256:3c9fff570f13480b201e9ab69453108f6d98244a7f495e91b6c654a47486ba43",
-                "sha256:415bdc7ca8c1c634a6d7163d43fb0ea885a07e9618a64bda407e04b04333b7db",
-                "sha256:42194f54c11abc8583417a7cf4eaff544ce0de8187abaf5d29029c91b1725ad3",
-                "sha256:4424e42199e86b21fc4db83bd76909a6fc2a2aefb352cb5414833c030f6ed71b",
-                "sha256:4a43c91840bda5f55249413037b7a9b79c90b1184ed504883b72c4df70778579",
-                "sha256:599a1e8ff057ac530c9ad1778293c665cb81a791421f46922d80a86473c13346",
-                "sha256:5c4fae4e9cdd18c82ba3a134be256e98dc0596af1e7285a3d2602c97dcfa5159",
-                "sha256:5ecfa867dea6fabe2a58f03ac9186ea64da1386af2159196da51c4904e11d652",
-                "sha256:62f2578358d3a92e4ab2d830cd1c2049c9c0d0e6d3c58322993cc341bdeac22e",
-                "sha256:6471a82d5abea994e38d2c2abc77164b4f7fbaaf80261cb98394d5793f11b12a",
-                "sha256:6d4f18483d040e18546108eb13b1dfa1000a089bcf8529e30346116ea6240506",
-                "sha256:71a608532ab3bd26223c8d841dde43f3516aa5d2bf37b50ac410bb5e99053e8f",
-                "sha256:74a1d8c85fb6ff0b30fbfa8ad0ac23cd601a138f7509dc617ebc65ef305bb98d",
-                "sha256:7b93a885bb13073afb0aa73ad82059a4c41f4b7d8eb8368980448b52d4c7dc2c",
-                "sha256:7d4751da932caaec419d514eaa4215eaf14b612cff66398dd51129ac22680b20",
-                "sha256:7f627141a26b551bdebbc4855c1157feeef18241b4b8366ed22a5c7d672ef858",
-                "sha256:8169cf44dd8f9071b2b9248c35fc35e8677451c52f795daa2bb4643f32a540bc",
-                "sha256:aa00d66c0fab27373ae44ae26a66a9e43ff2a678bf63a9c7c1a9a4d61172827a",
-                "sha256:ccb032fda0873254380aa2bfad2582aedc2959186cce61e3a17abc1a55ff89c3",
-                "sha256:d754f39e0d1603b5b24a7f8484b22d2904fa551fe865fd0d4c3332f078d20d4e",
-                "sha256:d75c461e20e29afc0aee7172a0950157c704ff0dd51613506bd7d82b718e7410",
-                "sha256:dcd65317dd15bc0451f3e01c80da2216a31916bdcffd6221ca1202d96584aa25",
-                "sha256:e570d3ab32e2c2861c4ebe6ffcad6a8abf9347432a37608fe1fbd157b3f0036b",
-                "sha256:fd43a88e045cf992ed09fa724b5315b790525f2676883a6ea64e3263bae6549d"
+                "sha256:001bf3242a1bb04d985d63e138230802c6c8d4db3668fb545fb5005ddf5bb5ff",
+                "sha256:00789914be39dffba161cfc5be31b55775de5ba2235fe49aa28c148236c4e06b",
+                "sha256:028a579fc9aed3af38f4892bdcc7390508adabc30c6af4a6e4f611b0c680e6ac",
+                "sha256:14491a910663bf9f13ddf2bc8f60562d6bc5315c1f09c704937ef17293fb85b0",
+                "sha256:1cae98a7054b5c9391eb3249b86e0e99ab1e02bb0cc0575da191aedadbdf4384",
+                "sha256:2089ed025da3919d2e75a4d963d008330c96751127dd6f73c8dc0c65041b4c26",
+                "sha256:2d384f4a127a15ba701207f7639d94106693b6cd64173d6c8988e2c25f3ac2b6",
+                "sha256:337d448e5a725bba2d8293c48d9353fc68d0e9e4088d62a9571def317797522b",
+                "sha256:399aed636c7d3749bbed55bc907c3288cb43c65c4389964ad5ff849b6370603e",
+                "sha256:3b911c2dbd4f423b4c4fcca138cadde747abdb20d196c4a48708b8a2d32b16dd",
+                "sha256:3d311bcc4a41408cf5854f06ef2c5cab88f9fded37a3b95936c9879c1640d4c2",
+                "sha256:62ae9af2d069ea2698bf536dcfe1e4eed9090211dbaafeeedf5cb6c41b352f66",
+                "sha256:66e41db66b47d0d8672d8ed2708ba91b2f2524ece3dee48b5dfb36be8c2f21dc",
+                "sha256:675686925a9fb403edba0114db74e741d8181683dcf216be697d208857e04ca8",
+                "sha256:7e63cbcf2429a8dbfe48dcc2322d5f2220b77b2e17b7ba023d6166d84655da55",
+                "sha256:8a6c688fefb4e1cd56feb6c511984a6c4f7ec7d2a1ff31a10254f3c817054ae4",
+                "sha256:8c0ffc886aea5df6a1762d0019e9cb05f825d0eec1f520c51be9d198701daee5",
+                "sha256:95cd16d3dee553f882540c1ffe331d085c9e629499ceadfbda4d4fde635f4b7d",
+                "sha256:99f748a7e71ff382613b4e1acc0ac83bf7ad167fb3802e35e90d9763daba4d78",
+                "sha256:b8c78301cefcf5fd914aad35d3c04c2b21ce8629b5e4f4e45ae6812e461910fa",
+                "sha256:c420917b188a5582a56d8b93bdd8e0f6eca08c84ff623a4c16e809152cd35793",
+                "sha256:c43866529f2f06fe0edc6246eb4faa34f03fe88b64a0a9a942561c8e22f4b71f",
+                "sha256:cab50b8c2250b46fe738c77dbd25ce017d5e6fb35d3407606e7a4180656a5a6a",
+                "sha256:cef128cb4d5e0b3493f058f10ce32365972c554572ff821e175dbc6f8ff6924f",
+                "sha256:cf16e3cf6c0a5fdd9bc10c21687e19d29ad1fe863372b5543deaec1039581a30",
+                "sha256:e56c744aa6ff427a607763346e4170629caf7e48ead6921745986db3692f987f",
+                "sha256:e577934fc5f8779c554639376beeaa5657d54349096ef24abe8c74c5d9c117c3",
+                "sha256:f2b0fa0c01d8a0c7483afd9f31d7ecf2d71760ca24499c8697aeb5ca37dc090c"
             ],
-            "version": "==1.13.2"
+            "version": "==1.14.0"
         },
         "chardet": {
             "hashes": [
@@ -138,10 +133,10 @@
         },
         "click": {
             "hashes": [
-                "sha256:2335065e6395b9e67ca716de5f7526736bfa6ceead690adf616d925bdc622b13",
-                "sha256:5b94b49521f6456670fdb30cd82a4eca9412788a93fa6dd6df72c94d5a8ff2d7"
+                "sha256:8a18b4ea89d8820c5d0c7da8a64b2c324b4dabb695804dbfea19b9be9d88c0cc",
+                "sha256:e345d143d80bf5ee7534056164e5e112ea5e22716bbb1ce727941f4c8b471b9a"
             ],
-            "version": "==7.0"
+            "version": "==7.1.1"
         },
         "click-default-group": {
             "hashes": [
@@ -158,21 +153,21 @@
         },
         "db-to-sqlite": {
             "hashes": [
-                "sha256:3b7b59663c89e046271c46226b74d141946a755582de5db99c6d69af27295d30"
+                "sha256:fcaaaf3ffc555c932f78785d33276c655ebe7458eea82589670c1588292dccb4"
             ],
             "index": "pypi",
-            "version": "==1.0.2"
+            "version": "==1.1.1"
         },
         "django": {
             "extras": [
                 "bcrypt"
             ],
             "hashes": [
-                "sha256:1226168be1b1c7efd0e66ee79b0e0b58b2caa7ed87717909cd8a57bb13a7079a",
-                "sha256:9a4635813e2d498a3c01b10c701fe4a515d76dd290aaa792ccb65ca4ccb6b038"
+                "sha256:65e2387e6bde531d3bb803244a2b74e0253550a9612c64a60c8c5be267b30f50",
+                "sha256:b51c9c548d5c3b3ccbb133d0bebc992e8ec3f14899bce8936e6fdda6b23a1881"
             ],
             "index": "pypi",
-            "version": "==2.2.10"
+            "version": "==2.2.11"
         },
         "django-anymail": {
             "extras": [
@@ -227,11 +222,11 @@
         },
         "django-mysql": {
             "hashes": [
-                "sha256:5ed13e3c4e4dc1671255bfc5a9f943320079af626a0c4d1a7f8baf276f5b9de2",
-                "sha256:6a6d3b2b4b094418d67cc064b110d8ac31ca98a67b535568cf829bf052c718db"
+                "sha256:b984dfe75bedeb01bfcb974fe8400c224a6b55677b98a799f1c96274d96c5a72",
+                "sha256:ceaf6d93396b7f7b3798ac5f9a819dd70d5f0e1112850f2a34c57f062fa19398"
             ],
             "index": "pypi",
-            "version": "==3.2.0"
+            "version": "==3.3.0"
         },
         "django-registration": {
             "hashes": [
@@ -258,10 +253,10 @@
         },
         "google-auth": {
             "hashes": [
-                "sha256:44549e69ac39acf41fdf47f3f39a06e4e68378476806760d94a2c6a361b2bb06",
-                "sha256:b2d83edc02a9deeed9b1b839046671fd9eda223d21bd2dd50051559787032fd8"
+                "sha256:4fddaf62bcfc3b9cc1bb2062130937a25ebe781b8eb15beec217c160b8cabb68",
+                "sha256:ec172006e626bb90f6069e9358c373bc991a15da6cc55276986d9ecd29235b15"
             ],
-            "version": "==1.11.0"
+            "version": "==1.11.3"
         },
         "google-cloud-core": {
             "hashes": [
@@ -272,11 +267,11 @@
         },
         "google-cloud-storage": {
             "hashes": [
-                "sha256:9f59c100d3940e38567c48d54cf1a2e7591a2f38e9693dfc11a242d5e54a1626",
-                "sha256:c66e876ae9547884fa42566a2ebfec51d280f488d7a058af9611ba90c78bed78"
+                "sha256:22f25d1c627b9b688b8873ea48203f337dd5448a242089e688d99c2fa46a8b89",
+                "sha256:ffdfaeb319c47deaf5b25c6bf1f1f52a183ba6abb0bb80586509a9b68dc35d31"
             ],
             "index": "pypi",
-            "version": "==1.23.0"
+            "version": "==1.26.0"
         },
         "google-resumable-media": {
             "hashes": [
@@ -354,9 +349,10 @@
         },
         "pycparser": {
             "hashes": [
-                "sha256:a988718abfad80b6b157acce7bf130a30876d27603738ac39f140993246b25b3"
+                "sha256:2d475327684562c3a96cc71adf7dc8c4f0565175cf86b6d7a404ff4c771f15f0",
+                "sha256:7582ad22678f0fcd81102833f60ef8d0e57288b6b5fb00323d101be910e35705"
             ],
-            "version": "==2.19"
+            "version": "==2.20"
         },
         "pytz": {
             "hashes": [
@@ -382,11 +378,11 @@
         },
         "sentry-sdk": {
             "hashes": [
-                "sha256:b06dd27391fd11fb32f84fe054e6a64736c469514a718a99fb5ce1dff95d6b28",
-                "sha256:e023da07cfbead3868e1e2ba994160517885a32dfd994fc455b118e37989479b"
+                "sha256:23808d571d2461a4ce3784ec12bbee5bdb8c026c143fe79d36cef8a6d653e71f",
+                "sha256:bb90a4e19c7233a580715fc986cc44be2c48fc10b31e71580a2037e1c94b6950"
             ],
             "index": "pypi",
-            "version": "==0.14.1"
+            "version": "==0.14.3"
         },
         "six": {
             "hashes": [
@@ -397,23 +393,23 @@
         },
         "sqlalchemy": {
             "hashes": [
-                "sha256:64a7b71846db6423807e96820993fa12a03b89127d278290ca25c0b11ed7b4fb"
+                "sha256:c4cca4aed606297afbe90d4306b49ad3a4cd36feb3f87e4bfd655c57fd9ef445"
             ],
-            "version": "==1.3.13"
+            "version": "==1.3.15"
         },
         "sqlite-utils": {
             "hashes": [
-                "sha256:64d20aa680468a5ed101fd4173ebd3aa8ddeafbe008d7a9f91934c2b8e21d846"
+                "sha256:216f64f8202762b34bd93a63b9a1d4a30e52d209af46c2879577be0e5039a30a"
             ],
             "index": "pypi",
-            "version": "==1.12.1"
+            "version": "==2.3.1"
         },
         "sqlparse": {
             "hashes": [
-                "sha256:40afe6b8d4b1117e7dff5504d7a8ce07d9a1b15aeeade8a2d10f130a834f8177",
-                "sha256:7c3dca29c022744e95b547e867cee89f4fce4373f3549ccd8797d8eb52cdb873"
+                "sha256:022fb9c87b524d1f7862b3037e541f68597a730a8843245c349fc93e1643dc4e",
+                "sha256:e162203737712307dfe78860cc56c8da8a852ab2ee33750e33aeadf38d12c548"
             ],
-            "version": "==0.3.0"
+            "version": "==0.3.1"
         },
         "tabulate": {
             "hashes": [
@@ -451,10 +447,10 @@
         },
         "asgiref": {
             "hashes": [
-                "sha256:7e06d934a7718bf3975acbf87780ba678957b87c7adc056f13b6215d610695a0",
-                "sha256:ea448f92fc35a0ef4b1508f53a04c4670255a3f33d22a81c8fc9c872036adbe5"
+                "sha256:3e4192eaec0758b99722f0b0666d5fbfaa713054d92e8de5b58ba84ec5ce696f",
+                "sha256:c8f49dd3b42edcc51d09dd2eea8a92b3cfc987ff7e6486be734b4d0cbfd5d315"
             ],
-            "version": "==3.2.3"
+            "version": "==3.2.5"
         },
         "astroid": {
             "hashes": [
@@ -462,6 +458,13 @@
                 "sha256:840947ebfa8b58f318d42301cf8c0a20fd794a33b61cc4638e28e9e61ba32f42"
             ],
             "version": "==2.3.3"
+        },
+        "attrs": {
+            "hashes": [
+                "sha256:08a96c641c3a74e44eb59afb61a24f2cb9f4d7188748e76ba4bb5edfa3cb7d1c",
+                "sha256:f7b7ce16570fe9965acd6d30101a28f62fb4a7f9e926b3bbc9b61f8b04247e72"
+            ],
+            "version": "==19.3.0"
         },
         "backcall": {
             "hashes": [
@@ -472,41 +475,36 @@
         },
         "cffi": {
             "hashes": [
-                "sha256:0b49274afc941c626b605fb59b59c3485c17dc776dc3cc7cc14aca74cc19cc42",
-                "sha256:0e3ea92942cb1168e38c05c1d56b0527ce31f1a370f6117f1d490b8dcd6b3a04",
-                "sha256:135f69aecbf4517d5b3d6429207b2dff49c876be724ac0c8bf8e1ea99df3d7e5",
-                "sha256:19db0cdd6e516f13329cba4903368bff9bb5a9331d3410b1b448daaadc495e54",
-                "sha256:2781e9ad0e9d47173c0093321bb5435a9dfae0ed6a762aabafa13108f5f7b2ba",
-                "sha256:291f7c42e21d72144bb1c1b2e825ec60f46d0a7468f5346841860454c7aa8f57",
-                "sha256:2c5e309ec482556397cb21ede0350c5e82f0eb2621de04b2633588d118da4396",
-                "sha256:2e9c80a8c3344a92cb04661115898a9129c074f7ab82011ef4b612f645939f12",
-                "sha256:32a262e2b90ffcfdd97c7a5e24a6012a43c61f1f5a57789ad80af1d26c6acd97",
-                "sha256:3c9fff570f13480b201e9ab69453108f6d98244a7f495e91b6c654a47486ba43",
-                "sha256:415bdc7ca8c1c634a6d7163d43fb0ea885a07e9618a64bda407e04b04333b7db",
-                "sha256:42194f54c11abc8583417a7cf4eaff544ce0de8187abaf5d29029c91b1725ad3",
-                "sha256:4424e42199e86b21fc4db83bd76909a6fc2a2aefb352cb5414833c030f6ed71b",
-                "sha256:4a43c91840bda5f55249413037b7a9b79c90b1184ed504883b72c4df70778579",
-                "sha256:599a1e8ff057ac530c9ad1778293c665cb81a791421f46922d80a86473c13346",
-                "sha256:5c4fae4e9cdd18c82ba3a134be256e98dc0596af1e7285a3d2602c97dcfa5159",
-                "sha256:5ecfa867dea6fabe2a58f03ac9186ea64da1386af2159196da51c4904e11d652",
-                "sha256:62f2578358d3a92e4ab2d830cd1c2049c9c0d0e6d3c58322993cc341bdeac22e",
-                "sha256:6471a82d5abea994e38d2c2abc77164b4f7fbaaf80261cb98394d5793f11b12a",
-                "sha256:6d4f18483d040e18546108eb13b1dfa1000a089bcf8529e30346116ea6240506",
-                "sha256:71a608532ab3bd26223c8d841dde43f3516aa5d2bf37b50ac410bb5e99053e8f",
-                "sha256:74a1d8c85fb6ff0b30fbfa8ad0ac23cd601a138f7509dc617ebc65ef305bb98d",
-                "sha256:7b93a885bb13073afb0aa73ad82059a4c41f4b7d8eb8368980448b52d4c7dc2c",
-                "sha256:7d4751da932caaec419d514eaa4215eaf14b612cff66398dd51129ac22680b20",
-                "sha256:7f627141a26b551bdebbc4855c1157feeef18241b4b8366ed22a5c7d672ef858",
-                "sha256:8169cf44dd8f9071b2b9248c35fc35e8677451c52f795daa2bb4643f32a540bc",
-                "sha256:aa00d66c0fab27373ae44ae26a66a9e43ff2a678bf63a9c7c1a9a4d61172827a",
-                "sha256:ccb032fda0873254380aa2bfad2582aedc2959186cce61e3a17abc1a55ff89c3",
-                "sha256:d754f39e0d1603b5b24a7f8484b22d2904fa551fe865fd0d4c3332f078d20d4e",
-                "sha256:d75c461e20e29afc0aee7172a0950157c704ff0dd51613506bd7d82b718e7410",
-                "sha256:dcd65317dd15bc0451f3e01c80da2216a31916bdcffd6221ca1202d96584aa25",
-                "sha256:e570d3ab32e2c2861c4ebe6ffcad6a8abf9347432a37608fe1fbd157b3f0036b",
-                "sha256:fd43a88e045cf992ed09fa724b5315b790525f2676883a6ea64e3263bae6549d"
+                "sha256:001bf3242a1bb04d985d63e138230802c6c8d4db3668fb545fb5005ddf5bb5ff",
+                "sha256:00789914be39dffba161cfc5be31b55775de5ba2235fe49aa28c148236c4e06b",
+                "sha256:028a579fc9aed3af38f4892bdcc7390508adabc30c6af4a6e4f611b0c680e6ac",
+                "sha256:14491a910663bf9f13ddf2bc8f60562d6bc5315c1f09c704937ef17293fb85b0",
+                "sha256:1cae98a7054b5c9391eb3249b86e0e99ab1e02bb0cc0575da191aedadbdf4384",
+                "sha256:2089ed025da3919d2e75a4d963d008330c96751127dd6f73c8dc0c65041b4c26",
+                "sha256:2d384f4a127a15ba701207f7639d94106693b6cd64173d6c8988e2c25f3ac2b6",
+                "sha256:337d448e5a725bba2d8293c48d9353fc68d0e9e4088d62a9571def317797522b",
+                "sha256:399aed636c7d3749bbed55bc907c3288cb43c65c4389964ad5ff849b6370603e",
+                "sha256:3b911c2dbd4f423b4c4fcca138cadde747abdb20d196c4a48708b8a2d32b16dd",
+                "sha256:3d311bcc4a41408cf5854f06ef2c5cab88f9fded37a3b95936c9879c1640d4c2",
+                "sha256:62ae9af2d069ea2698bf536dcfe1e4eed9090211dbaafeeedf5cb6c41b352f66",
+                "sha256:66e41db66b47d0d8672d8ed2708ba91b2f2524ece3dee48b5dfb36be8c2f21dc",
+                "sha256:675686925a9fb403edba0114db74e741d8181683dcf216be697d208857e04ca8",
+                "sha256:7e63cbcf2429a8dbfe48dcc2322d5f2220b77b2e17b7ba023d6166d84655da55",
+                "sha256:8a6c688fefb4e1cd56feb6c511984a6c4f7ec7d2a1ff31a10254f3c817054ae4",
+                "sha256:8c0ffc886aea5df6a1762d0019e9cb05f825d0eec1f520c51be9d198701daee5",
+                "sha256:95cd16d3dee553f882540c1ffe331d085c9e629499ceadfbda4d4fde635f4b7d",
+                "sha256:99f748a7e71ff382613b4e1acc0ac83bf7ad167fb3802e35e90d9763daba4d78",
+                "sha256:b8c78301cefcf5fd914aad35d3c04c2b21ce8629b5e4f4e45ae6812e461910fa",
+                "sha256:c420917b188a5582a56d8b93bdd8e0f6eca08c84ff623a4c16e809152cd35793",
+                "sha256:c43866529f2f06fe0edc6246eb4faa34f03fe88b64a0a9a942561c8e22f4b71f",
+                "sha256:cab50b8c2250b46fe738c77dbd25ce017d5e6fb35d3407606e7a4180656a5a6a",
+                "sha256:cef128cb4d5e0b3493f058f10ce32365972c554572ff821e175dbc6f8ff6924f",
+                "sha256:cf16e3cf6c0a5fdd9bc10c21687e19d29ad1fe863372b5543deaec1039581a30",
+                "sha256:e56c744aa6ff427a607763346e4170629caf7e48ead6921745986db3692f987f",
+                "sha256:e577934fc5f8779c554639376beeaa5657d54349096ef24abe8c74c5d9c117c3",
+                "sha256:f2b0fa0c01d8a0c7483afd9f31d7ecf2d71760ca24499c8697aeb5ca37dc090c"
             ],
-            "version": "==1.13.2"
+            "version": "==1.14.0"
         },
         "cli-helpers": {
             "extras": [
@@ -521,10 +519,17 @@
         },
         "click": {
             "hashes": [
-                "sha256:2335065e6395b9e67ca716de5f7526736bfa6ceead690adf616d925bdc622b13",
-                "sha256:5b94b49521f6456670fdb30cd82a4eca9412788a93fa6dd6df72c94d5a8ff2d7"
+                "sha256:8a18b4ea89d8820c5d0c7da8a64b2c324b4dabb695804dbfea19b9be9d88c0cc",
+                "sha256:e345d143d80bf5ee7534056164e5e112ea5e22716bbb1ce727941f4c8b471b9a"
             ],
-            "version": "==7.0"
+            "version": "==7.1.1"
+        },
+        "colorama": {
+            "hashes": [
+                "sha256:7d73d2a99753107a36ac6b455ee49046802e59d9d076ef8e47b61499fa29afff",
+                "sha256:e96da0d330793e2cb9485e9ddfd918d456036c7149416295932478192f4436a1"
+            ],
+            "version": "==0.4.3"
         },
         "configobj": {
             "hashes": [
@@ -534,40 +539,40 @@
         },
         "coverage": {
             "hashes": [
-                "sha256:15cf13a6896048d6d947bf7d222f36e4809ab926894beb748fc9caa14605d9c3",
-                "sha256:1daa3eceed220f9fdb80d5ff950dd95112cd27f70d004c7918ca6dfc6c47054c",
-                "sha256:1e44a022500d944d42f94df76727ba3fc0a5c0b672c358b61067abb88caee7a0",
-                "sha256:25dbf1110d70bab68a74b4b9d74f30e99b177cde3388e07cc7272f2168bd1477",
-                "sha256:3230d1003eec018ad4a472d254991e34241e0bbd513e97a29727c7c2f637bd2a",
-                "sha256:3dbb72eaeea5763676a1a1efd9b427a048c97c39ed92e13336e726117d0b72bf",
-                "sha256:5012d3b8d5a500834783689a5d2292fe06ec75dc86ee1ccdad04b6f5bf231691",
-                "sha256:51bc7710b13a2ae0c726f69756cf7ffd4362f4ac36546e243136187cfcc8aa73",
-                "sha256:527b4f316e6bf7755082a783726da20671a0cc388b786a64417780b90565b987",
-                "sha256:722e4557c8039aad9592c6a4213db75da08c2cd9945320220634f637251c3894",
-                "sha256:76e2057e8ffba5472fd28a3a010431fd9e928885ff480cb278877c6e9943cc2e",
-                "sha256:77afca04240c40450c331fa796b3eab6f1e15c5ecf8bf2b8bee9706cd5452fef",
-                "sha256:7afad9835e7a651d3551eab18cbc0fdb888f0a6136169fbef0662d9cdc9987cf",
-                "sha256:9bea19ac2f08672636350f203db89382121c9c2ade85d945953ef3c8cf9d2a68",
-                "sha256:a8b8ac7876bc3598e43e2603f772d2353d9931709345ad6c1149009fd1bc81b8",
-                "sha256:b0840b45187699affd4c6588286d429cd79a99d509fe3de0f209594669bb0954",
-                "sha256:b26aaf69713e5674efbde4d728fb7124e429c9466aeaf5f4a7e9e699b12c9fe2",
-                "sha256:b63dd43f455ba878e5e9f80ba4f748c0a2156dde6e0e6e690310e24d6e8caf40",
-                "sha256:be18f4ae5a9e46edae3f329de2191747966a34a3d93046dbdf897319923923bc",
-                "sha256:c312e57847db2526bc92b9bfa78266bfbaabac3fdcd751df4d062cd4c23e46dc",
-                "sha256:c60097190fe9dc2b329a0eb03393e2e0829156a589bd732e70794c0dd804258e",
-                "sha256:c62a2143e1313944bf4a5ab34fd3b4be15367a02e9478b0ce800cb510e3bbb9d",
-                "sha256:cc1109f54a14d940b8512ee9f1c3975c181bbb200306c6d8b87d93376538782f",
-                "sha256:cd60f507c125ac0ad83f05803063bed27e50fa903b9c2cfee3f8a6867ca600fc",
-                "sha256:d513cc3db248e566e07a0da99c230aca3556d9b09ed02f420664e2da97eac301",
-                "sha256:d649dc0bcace6fcdb446ae02b98798a856593b19b637c1b9af8edadf2b150bea",
-                "sha256:d7008a6796095a79544f4da1ee49418901961c97ca9e9d44904205ff7d6aa8cb",
-                "sha256:da93027835164b8223e8e5af2cf902a4c80ed93cb0909417234f4a9df3bcd9af",
-                "sha256:e69215621707119c6baf99bda014a45b999d37602cb7043d943c76a59b05bf52",
-                "sha256:ea9525e0fef2de9208250d6c5aeeee0138921057cd67fcef90fbed49c4d62d37",
-                "sha256:fca1669d464f0c9831fd10be2eef6b86f5ebd76c724d1e0706ebdff86bb4adf0"
+                "sha256:03f630aba2b9b0d69871c2e8d23a69b7fe94a1e2f5f10df5049c0df99db639a0",
+                "sha256:046a1a742e66d065d16fb564a26c2a15867f17695e7f3d358d7b1ad8a61bca30",
+                "sha256:0a907199566269e1cfa304325cc3b45c72ae341fbb3253ddde19fa820ded7a8b",
+                "sha256:165a48268bfb5a77e2d9dbb80de7ea917332a79c7adb747bd005b3a07ff8caf0",
+                "sha256:1b60a95fc995649464e0cd48cecc8288bac5f4198f21d04b8229dc4097d76823",
+                "sha256:1f66cf263ec77af5b8fe14ef14c5e46e2eb4a795ac495ad7c03adc72ae43fafe",
+                "sha256:2e08c32cbede4a29e2a701822291ae2bc9b5220a971bba9d1e7615312efd3037",
+                "sha256:3844c3dab800ca8536f75ae89f3cf566848a3eb2af4d9f7b1103b4f4f7a5dad6",
+                "sha256:408ce64078398b2ee2ec08199ea3fcf382828d2f8a19c5a5ba2946fe5ddc6c31",
+                "sha256:443be7602c790960b9514567917af538cac7807a7c0c0727c4d2bbd4014920fd",
+                "sha256:4482f69e0701139d0f2c44f3c395d1d1d37abd81bfafbf9b6efbe2542679d892",
+                "sha256:4a8a259bf990044351baf69d3b23e575699dd60b18460c71e81dc565f5819ac1",
+                "sha256:513e6526e0082c59a984448f4104c9bf346c2da9961779ede1fc458e8e8a1f78",
+                "sha256:5f587dfd83cb669933186661a351ad6fc7166273bc3e3a1531ec5c783d997aac",
+                "sha256:62061e87071497951155cbccee487980524d7abea647a1b2a6eb6b9647df9006",
+                "sha256:641e329e7f2c01531c45c687efcec8aeca2a78a4ff26d49184dce3d53fc35014",
+                "sha256:65a7e00c00472cd0f59ae09d2fb8a8aaae7f4a0cf54b2b74f3138d9f9ceb9cb2",
+                "sha256:6ad6ca45e9e92c05295f638e78cd42bfaaf8ee07878c9ed73e93190b26c125f7",
+                "sha256:73aa6e86034dad9f00f4bbf5a666a889d17d79db73bc5af04abd6c20a014d9c8",
+                "sha256:7c9762f80a25d8d0e4ab3cb1af5d9dffbddb3ee5d21c43e3474c84bf5ff941f7",
+                "sha256:85596aa5d9aac1bf39fe39d9fa1051b0f00823982a1de5766e35d495b4a36ca9",
+                "sha256:86a0ea78fd851b313b2e712266f663e13b6bc78c2fb260b079e8b67d970474b1",
+                "sha256:8a620767b8209f3446197c0e29ba895d75a1e272a36af0786ec70fe7834e4307",
+                "sha256:922fb9ef2c67c3ab20e22948dcfd783397e4c043a5c5fa5ff5e9df5529074b0a",
+                "sha256:9fad78c13e71546a76c2f8789623eec8e499f8d2d799f4b4547162ce0a4df435",
+                "sha256:a37c6233b28e5bc340054cf6170e7090a4e85069513320275a4dc929144dccf0",
+                "sha256:c3fc325ce4cbf902d05a80daa47b645d07e796a80682c1c5800d6ac5045193e5",
+                "sha256:cda33311cb9fb9323958a69499a667bd728a39a7aa4718d7622597a44c4f1441",
+                "sha256:db1d4e38c9b15be1521722e946ee24f6db95b189d1447fa9ff18dd16ba89f732",
+                "sha256:eda55e6e9ea258f5e4add23bcf33dc53b2c319e70806e180aecbff8d90ea24de",
+                "sha256:f372cdbb240e09ee855735b9d85e7f50730dcfb6296b74b95a3e5dea0615c4c1"
             ],
             "index": "pypi",
-            "version": "==5.0.3"
+            "version": "==5.0.4"
         },
         "cryptography": {
             "hashes": [
@@ -597,21 +602,21 @@
         },
         "decorator": {
             "hashes": [
-                "sha256:54c38050039232e1db4ad7375cfce6748d7b41c29e95a081c8a6d2c30364a2ce",
-                "sha256:5d19b92a3c8f7f101c8dd86afd86b0f061a8ce4540ab8cd401fa2542756bce6d"
+                "sha256:41fa54c2a0cc4ba648be4fd43cff00aedf5b9465c9bf18d64325bc225f08f760",
+                "sha256:e3a62f0520172440ca0dcc823749319382e377f37f140a0b99ef45fecb84bfe7"
             ],
-            "version": "==4.4.1"
+            "version": "==4.4.2"
         },
         "django": {
             "extras": [
                 "bcrypt"
             ],
             "hashes": [
-                "sha256:1226168be1b1c7efd0e66ee79b0e0b58b2caa7ed87717909cd8a57bb13a7079a",
-                "sha256:9a4635813e2d498a3c01b10c701fe4a515d76dd290aaa792ccb65ca4ccb6b038"
+                "sha256:65e2387e6bde531d3bb803244a2b74e0253550a9612c64a60c8c5be267b30f50",
+                "sha256:b51c9c548d5c3b3ccbb133d0bebc992e8ec3f14899bce8936e6fdda6b23a1881"
             ],
             "index": "pypi",
-            "version": "==2.2.10"
+            "version": "==2.2.11"
         },
         "django-debug-toolbar": {
             "hashes": [
@@ -620,6 +625,12 @@
             ],
             "index": "pypi",
             "version": "==2.2"
+        },
+        "docopt": {
+            "hashes": [
+                "sha256:49b3a825280bd66b3aa83585ef59c4a8c82f2c8a522dbe754a8bc8d08c85c491"
+            ],
+            "version": "==0.6.2"
         },
         "entrypoints": {
             "hashes": [
@@ -636,20 +647,28 @@
             "index": "pypi",
             "version": "==3.7.9"
         },
+        "importlib-metadata": {
+            "hashes": [
+                "sha256:06f5b3a99029c7134207dd882428a66992a9de2bef7c2b699b5641f9886c3302",
+                "sha256:b97607a1a18a5100839aec1dc26a1ea17ee0d93b20b0f008d80a5a050afb200b"
+            ],
+            "markers": "python_version < '3.8'",
+            "version": "==1.5.0"
+        },
         "ipdb": {
             "hashes": [
-                "sha256:5d9a4a0e3b7027a158fc6f2929934341045b9c3b0b86ed5d7e84e409653f72fd"
+                "sha256:77fb1c2a6fccdfee0136078c9ed6fe547ab00db00bebff181f1e8c9e13418d49"
             ],
             "index": "pypi",
-            "version": "==0.12.3"
+            "version": "==0.13.2"
         },
         "ipython": {
             "hashes": [
-                "sha256:d9459e7237e2e5858738ff9c3e26504b79899b58a6d49e574d352493d80684c6",
-                "sha256:f6689108b1734501d3b59c84427259fd5ac5141afe2e846cfa8598eb811886c9"
+                "sha256:ca478e52ae1f88da0102360e57e528b92f3ae4316aabac80a2cd7f7ab2efb48a",
+                "sha256:eb8d075de37f678424527b5ef6ea23f7b80240ca031c2dd6de5879d687a65333"
             ],
             "index": "pypi",
-            "version": "==7.12.0"
+            "version": "==7.13.0"
         },
         "ipython-genutils": {
             "hashes": [
@@ -705,6 +724,13 @@
             ],
             "version": "==0.6.1"
         },
+        "more-itertools": {
+            "hashes": [
+                "sha256:5dd8bcf33e5f9513ffa06d5ad33d78f31e1931ac9a18f33d37e77a180d393a7c",
+                "sha256:b1ddb932186d8a6ac451e1d95844b382f55e12686d51ca0c68b6f61f2ab7a507"
+            ],
+            "version": "==8.2.0"
+        },
         "mycli": {
             "hashes": [
                 "sha256:06e8b24df0b02b7c475c81589cdbd778139a71ae99a2d7a3bfc59ef5ab52b7ef",
@@ -713,12 +739,25 @@
             "index": "pypi",
             "version": "==1.20.1"
         },
+        "packaging": {
+            "hashes": [
+                "sha256:3c292b474fda1671ec57d46d739d072bfd495a4f51ad01a055121d81e952b7a3",
+                "sha256:82f77b9bee21c1bafbf35a84905d604d5d1223801d639cf3ed140bd651c08752"
+            ],
+            "version": "==20.3"
+        },
         "parso": {
             "hashes": [
-                "sha256:56b2105a80e9c4df49de85e125feb6be69f49920e121406f15e7acde6c9dfc57",
-                "sha256:951af01f61e6dccd04159042a0706a31ad437864ec6e25d0d7a96a9fbb9b0095"
+                "sha256:0c5659e0c6eba20636f99a04f469798dca8da279645ce5c387315b2c23912157",
+                "sha256:8515fc12cfca6ee3aa59138741fc5624d62340c97e401c74875769948d4f2995"
             ],
-            "version": "==0.6.1"
+            "version": "==0.6.2"
+        },
+        "pathtools": {
+            "hashes": [
+                "sha256:7c35c5421a39bb82e58018febd90e3b6e5db34c5443aaaf742b3f33d4655f1c0"
+            ],
+            "version": "==0.1.2"
         },
         "pexpect": {
             "hashes": [
@@ -735,12 +774,19 @@
             ],
             "version": "==0.7.5"
         },
+        "pluggy": {
+            "hashes": [
+                "sha256:15b2acde666561e1298d71b523007ed7364de07029219b604cf808bfa1c765b0",
+                "sha256:966c145cd83c96502c3c3868f50408687b38434af77734af1e9ca461a4081d2d"
+            ],
+            "version": "==0.13.1"
+        },
         "prompt-toolkit": {
             "hashes": [
-                "sha256:a402e9bf468b63314e37460b68ba68243d55b2f8c4d0192f85a019af3945050e",
-                "sha256:c93e53af97f630f12f5f62a3274e79527936ed466f038953dfa379d4941f651a"
+                "sha256:859e1b205b6cf6a51fa57fa34202e45365cf58f8338f0ee9f4e84a4165b37d5b",
+                "sha256:ebe6b1b08c888b84c50d7f93dee21a09af39860144ff6130aadbd61ae8d29783"
             ],
-            "version": "==3.0.3"
+            "version": "==3.0.4"
         },
         "ptyprocess": {
             "hashes": [
@@ -748,6 +794,13 @@
                 "sha256:d7cc528d76e76342423ca640335bd3633420dc1366f258cb31d05e865ef5ca1f"
             ],
             "version": "==0.6.0"
+        },
+        "py": {
+            "hashes": [
+                "sha256:5e27081401262157467ad6e7f851b7aa402c5852dbcb3dae06768434de5752aa",
+                "sha256:c20fdd83a5dbc0af9efd622bee9a5564e278f6380fffcacc43ba6f43db2813b0"
+            ],
+            "version": "==1.8.1"
         },
         "pycodestyle": {
             "hashes": [
@@ -758,9 +811,10 @@
         },
         "pycparser": {
             "hashes": [
-                "sha256:a988718abfad80b6b157acce7bf130a30876d27603738ac39f140993246b25b3"
+                "sha256:2d475327684562c3a96cc71adf7dc8c4f0565175cf86b6d7a404ff4c771f15f0",
+                "sha256:7582ad22678f0fcd81102833f60ef8d0e57288b6b5fb00323d101be910e35705"
             ],
-            "version": "==2.19"
+            "version": "==2.20"
         },
         "pyflakes": {
             "hashes": [
@@ -771,10 +825,10 @@
         },
         "pygments": {
             "hashes": [
-                "sha256:2a3fe295e54a20164a9df49c75fa58526d3be48e14aceba6d6b1e8ac0bfd6f1b",
-                "sha256:98c8aa5a9f778fcd1026a17361ddaf7330d1b7c62ae97c3bb0ae73e0b9b6b0fe"
+                "sha256:647344a061c249a3b74e230c739f434d7ea4d8b1d5f3721bc0f3558049b38f44",
+                "sha256:ff7a40b4860b727ab48fad6360eb351cc1b33cbf9b15a0f689ca5353e9463324"
             ],
-            "version": "==2.5.2"
+            "version": "==2.6.1"
         },
         "pylint": {
             "hashes": [
@@ -786,11 +840,11 @@
         },
         "pylint-django": {
             "hashes": [
-                "sha256:440beb814464928aedd2e21196bb6e47a83b63e2cbe886a701ba0f4a64206bbb",
-                "sha256:d5d113605a64cf0e638b707d4cb42106e626f8851bc30a44d5b22bd698ad8483"
+                "sha256:3a4cc19dd6301fc2d36c9fb6e15163001a6d12723c1f7f8c2249223c2a8c68f0",
+                "sha256:c9bbcff6b87ee8466fae274fd7aae3d2d3d4c4d1ea20c48cbce673e837e36048"
             ],
             "index": "pypi",
-            "version": "==2.0.13"
+            "version": "==2.0.14"
         },
         "pylint-plugin-utils": {
             "hashes": [
@@ -805,6 +859,36 @@
                 "sha256:d8c059dcd81dedb85a9f034d5e22dcb4442c0b201908bede99e306d65ea7c8e7"
             ],
             "version": "==0.9.3"
+        },
+        "pyparsing": {
+            "hashes": [
+                "sha256:4c830582a84fb022400b85429791bc551f1f4871c33f23e44f353119e92f969f",
+                "sha256:c342dccb5250c08d45fd6f8b4a559613ca603b57498511740e65cd11a2e7dcec"
+            ],
+            "version": "==2.4.6"
+        },
+        "pytest": {
+            "hashes": [
+                "sha256:0e5b30f5cb04e887b91b1ee519fa3d89049595f428c1db76e73bd7f17b09b172",
+                "sha256:84dde37075b8805f3d1f392cc47e38a0e59518fb46a431cfdaf7cf1ce805f970"
+            ],
+            "index": "pypi",
+            "version": "==5.4.1"
+        },
+        "pytest-django": {
+            "hashes": [
+                "sha256:456fa6854d04ee625d6bbb8b38ca2259e7040a6f93333bfe8bc8159b7e987203",
+                "sha256:489b904f695f9fb880ce591cf5a4979880afb467763b1f180c07574554bdfd26"
+            ],
+            "index": "pypi",
+            "version": "==3.8.0"
+        },
+        "pytest-watch": {
+            "hashes": [
+                "sha256:06136f03d5b361718b8d0d234042f7b2f203910d8568f63df2f866b547b3d4b9"
+            ],
+            "index": "pypi",
+            "version": "==4.2.0"
         },
         "pytz": {
             "hashes": [
@@ -822,10 +906,10 @@
         },
         "sqlparse": {
             "hashes": [
-                "sha256:40afe6b8d4b1117e7dff5504d7a8ce07d9a1b15aeeade8a2d10f130a834f8177",
-                "sha256:7c3dca29c022744e95b547e867cee89f4fce4373f3549ccd8797d8eb52cdb873"
+                "sha256:022fb9c87b524d1f7862b3037e541f68597a730a8843245c349fc93e1643dc4e",
+                "sha256:e162203737712307dfe78860cc56c8da8a852ab2ee33750e33aeadf38d12c548"
             ],
-            "version": "==0.3.0"
+            "version": "==0.3.1"
         },
         "tabulate": {
             "hashes": [
@@ -873,6 +957,12 @@
             "markers": "implementation_name == 'cpython' and python_version < '3.8'",
             "version": "==1.4.1"
         },
+        "watchdog": {
+            "hashes": [
+                "sha256:c560efb643faed5ef28784b2245cf8874f939569717a4a12826a173ac644456b"
+            ],
+            "version": "==0.10.2"
+        },
         "wcwidth": {
             "hashes": [
                 "sha256:8fd29383f539be45b20bd4df0dc29c20ba48654a41e661925e612311e9f3c603",
@@ -882,17 +972,24 @@
         },
         "werkzeug": {
             "hashes": [
-                "sha256:1e0dedc2acb1f46827daa2e399c1485c8fa17c0d8e70b6b875b4e7f54bf408d2",
-                "sha256:b353856d37dec59d6511359f97f6a4b2468442e454bd1c98298ddce53cac1f04"
+                "sha256:169ba8a33788476292d04186ab33b01d6add475033dfc07215e6d219cc077096",
+                "sha256:6dc65cf9091cf750012f56f2cad759fa9e879f511b5ff8685e456b4e3bf90d16"
             ],
             "index": "pypi",
-            "version": "==0.16.1"
+            "version": "==1.0.0"
         },
         "wrapt": {
             "hashes": [
                 "sha256:565a021fd19419476b9362b05eeaa094178de64f8361e44468f9e9d7843901e1"
             ],
             "version": "==1.11.2"
+        },
+        "zipp": {
+            "hashes": [
+                "sha256:aa36550ff0c0b7ef7fa639055d797116ee891440eac1a56f378e2d3179e0320b",
+                "sha256:c599e4d75c98f6798c509911d08a22e6c021d074469042177c8c86fb92eefd96"
+            ],
+            "version": "==3.1.0"
         }
     }
 }

--- a/apps/greencheck/fixtures/ip_ranges.json
+++ b/apps/greencheck/fixtures/ip_ranges.json
@@ -1,0 +1,13128 @@
+{
+  "syncToken": "1584643391",
+  "createDate": "2020-03-19-18-43-11",
+  "prefixes": [
+    {
+      "ip_prefix": "13.248.118.0/24",
+      "region": "eu-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "18.208.0.0/13",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.95.245.0/24",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.240.17.0/24",
+      "region": "ap-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "99.77.142.0/24",
+      "region": "ap-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.194.0.0/15",
+      "region": "ap-northeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.155.0.0/16",
+      "region": "eu-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.196.0.0/15",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "99.78.170.0/23",
+      "region": "ap-southeast-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "176.32.125.226/31",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.94.22.0/24",
+      "region": "us-gov-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.95.255.112/28",
+      "region": "us-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "13.210.0.0/15",
+      "region": "ap-southeast-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.94.17.0/24",
+      "region": "eu-central-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.95.154.0/23",
+      "region": "eu-west-3",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.95.212.0/22",
+      "region": "ap-southeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.239.0.240/28",
+      "region": "eu-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.241.0.0/16",
+      "region": "us-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "184.169.128.0/17",
+      "region": "us-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "216.182.224.0/21",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "13.248.124.0/24",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "15.193.2.0/24",
+      "region": "ap-southeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "99.77.132.0/24",
+      "region": "us-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.74.0.0/16",
+      "region": "ap-southeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.168.0.0/16",
+      "region": "ap-northeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.239.54.0/23",
+      "region": "eu-central-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "13.248.106.0/24",
+      "region": "me-south-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.119.224.0/21",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.219.64.0/22",
+      "region": "ap-south-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.238.0.0/16",
+      "region": "ap-northeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "150.222.117.0/24",
+      "region": "eu-north-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "216.182.232.0/22",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.92.72.0/22",
+      "region": "sa-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "99.82.184.0/22",
+      "region": "ap-southeast-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "150.222.121.0/24",
+      "region": "eu-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "172.96.98.0/24",
+      "region": "eu-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "3.5.16.0/21",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "13.125.0.0/16",
+      "region": "ap-northeast-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "13.248.24.0/22",
+      "region": "ap-northeast-3",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "13.248.103.0/24",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.193.0.0/16",
+      "region": "us-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.222.59.0/24",
+      "region": "cn-north-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "99.77.247.0/24",
+      "region": "eu-central-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "150.222.140.0/24",
+      "region": "us-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.95.104.0/22",
+      "region": "eu-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.119.249.0/24",
+      "region": "me-south-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "150.222.85.0/24",
+      "region": "eu-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "13.248.100.0/24",
+      "region": "eu-north-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.92.64.0/22",
+      "region": "sa-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.93.5.0/24",
+      "region": "ca-central-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.93.120.178/32",
+      "region": "us-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.144.193.128/26",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.250.0.0/16",
+      "region": "ap-northeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "107.20.0.0/14",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.93.8.0/22",
+      "region": "ap-southeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.94.224.0/20",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "99.77.128.0/24",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "150.222.88.0/24",
+      "region": "cn-north-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "15.177.77.0/24",
+      "region": "ap-northeast-3",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.46.224.0/20",
+      "region": "us-gov-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.95.156.0/24",
+      "region": "eu-west-3",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.180.0.0/15",
+      "region": "ap-northeast-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "99.77.253.0/24",
+      "region": "us-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "150.222.71.0/24",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "3.5.208.0/22",
+      "region": "ap-south-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "15.177.76.0/24",
+      "region": "ap-northeast-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.30.0.0/15",
+      "region": "eu-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.94.8.0/24",
+      "region": "ap-northeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.94.249.64/28",
+      "region": "us-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.92.0.0/17",
+      "region": "ap-northeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.154.0.0/16",
+      "region": "eu-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "67.202.0.0/18",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "103.246.148.0/23",
+      "region": "ap-southeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.93.20.17/32",
+      "region": "us-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.95.0.0/20",
+      "region": "us-east-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "205.251.246.0/24",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.94.248.112/28",
+      "region": "eu-central-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "144.220.0.0/16",
+      "region": "GLOBAL",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.93.17.0/24",
+      "region": "eu-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.95.150.0/24",
+      "region": "eu-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.219.60.0/23",
+      "region": "ap-northeast-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "15.197.2.0/24",
+      "region": "GLOBAL",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "15.221.20.0/22",
+      "region": "ap-southeast-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.94.198.32/28",
+      "region": "us-gov-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.232.0.0/16",
+      "region": "sa-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "199.127.232.0/22",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "13.248.123.0/24",
+      "region": "eu-central-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.93.249.0/24",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "207.171.160.0/20",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.92.48.0/22",
+      "region": "us-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.94.116.0/22",
+      "region": "us-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.144.215.200/31",
+      "region": "eu-north-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "208.86.90.0/23",
+      "region": "eu-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "3.136.0.0/13",
+      "region": "us-east-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "13.248.99.0/24",
+      "region": "us-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.93.37.223/32",
+      "region": "us-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.94.248.192/28",
+      "region": "eu-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "150.222.223.0/24",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "15.230.23.0/24",
+      "region": "ap-southeast-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.94.20.0/24",
+      "region": "ap-south-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.92.0.0/20",
+      "region": "ap-northeast-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.95.80.0/20",
+      "region": "ap-south-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.219.132.0/22",
+      "region": "ap-southeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "176.32.124.128/25",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "184.73.0.0/16",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "18.183.0.0/16",
+      "region": "ap-northeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "46.137.0.0/17",
+      "region": "eu-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.93.60.0/24",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "99.77.135.0/24",
+      "region": "eu-west-3",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "150.222.243.26/31",
+      "region": "eu-central-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.144.208.64/26",
+      "region": "eu-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "99.78.172.0/24",
+      "region": "eu-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "150.222.136.0/24",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "3.80.0.0/12",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "3.101.0.0/16",
+      "region": "us-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.40.0.0/14",
+      "region": "us-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.95.170.0/23",
+      "region": "eu-north-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.124.128.0/17",
+      "region": "GLOBAL",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "150.222.77.0/24",
+      "region": "ap-northeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "150.222.90.0/24",
+      "region": "ap-northeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "15.193.4.0/24",
+      "region": "eu-central-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.239.106.0/23",
+      "region": "eu-central-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "35.181.0.0/16",
+      "region": "eu-west-3",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.93.138.252/32",
+      "region": "eu-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.80.0.0/13",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.214.0.0/16",
+      "region": "us-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.254.0.0/16",
+      "region": "ap-southeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "99.78.176.0/21",
+      "region": "us-east-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.93.99.0/24",
+      "region": "ap-south-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.95.40.0/24",
+      "region": "us-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.95.254.0/24",
+      "region": "eu-west-3",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.144.228.192/26",
+      "region": "ap-northeast-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "176.32.64.0/19",
+      "region": "ap-northeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "3.224.0.0/12",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.94.216.0/21",
+      "region": "eu-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.144.192.192/26",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.144.196.192/26",
+      "region": "us-east-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.221.0.0/16",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.240.202.0/24",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.255.0.0/16",
+      "region": "ap-southeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "18.253.0.0/16",
+      "region": "us-gov-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.46.192.0/20",
+      "region": "eu-north-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.82.187.0/24",
+      "region": "cn-northwest-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.93.139.253/32",
+      "region": "eu-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.94.249.112/28",
+      "region": "us-gov-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.230.0.0/16",
+      "region": "GLOBAL",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "13.208.0.0/16",
+      "region": "ap-northeast-3",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "15.193.7.0/24",
+      "region": "us-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.93.96.0/24",
+      "region": "eu-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.156.0.0/14",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.236.0.0/15",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "13.248.122.0/24",
+      "region": "eu-north-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.95.249.0/24",
+      "region": "ap-south-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.239.1.82/32",
+      "region": "ap-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.244.0.0/16",
+      "region": "us-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "99.82.174.0/24",
+      "region": "ca-central-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.93.12.12/32",
+      "region": "us-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.95.255.128/28",
+      "region": "eu-central-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.208.0.0/13",
+      "region": "eu-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.239.0.208/28",
+      "region": "ap-south-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "103.246.150.0/23",
+      "region": "ap-northeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "150.222.10.0/24",
+      "region": "eu-central-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "13.228.0.0/15",
+      "region": "ap-southeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.94.248.96/28",
+      "region": "us-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.196.0.0/14",
+      "region": "ap-northeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "99.77.150.0/24",
+      "region": "ca-central-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "99.78.208.0/22",
+      "region": "ap-northeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.32.0.0/14",
+      "region": "us-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.95.252.0/24",
+      "region": "ap-northeast-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.119.192.0/22",
+      "region": "eu-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.222.36.0/22",
+      "region": "cn-north-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "150.222.142.0/24",
+      "region": "ap-southeast-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "150.222.222.0/24",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.18.0.0/15",
+      "region": "eu-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.92.56.0/22",
+      "region": "ap-southeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.93.21.14/32",
+      "region": "eu-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.93.76.0/24",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.94.19.0/24",
+      "region": "ap-northeast-3",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.239.1.112/28",
+      "region": "me-south-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.239.52.0/23",
+      "region": "ap-northeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "108.166.240.0/21",
+      "region": "us-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "175.41.192.0/18",
+      "region": "ap-northeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "205.251.228.0/22",
+      "region": "us-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.94.248.160/28",
+      "region": "us-east-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.151.0.0/17",
+      "region": "us-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "13.54.0.0/15",
+      "region": "ap-southeast-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "13.248.48.0/21",
+      "region": "ap-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.95.142.0/23",
+      "region": "us-gov-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.95.241.0/24",
+      "region": "ap-southeast-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.231.232.0/21",
+      "region": "us-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.239.128.0/18",
+      "region": "GLOBAL",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "99.77.144.0/24",
+      "region": "ap-southeast-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "99.78.160.0/21",
+      "region": "eu-central-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "150.222.72.0/24",
+      "region": "ap-southeast-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.222.52.0/22",
+      "region": "cn-north-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "150.222.243.28/31",
+      "region": "eu-central-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.144.209.192/26",
+      "region": "eu-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.144.218.0/26",
+      "region": "eu-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "99.80.0.0/15",
+      "region": "eu-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "3.34.0.0/15",
+      "region": "ap-northeast-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "15.177.74.0/24",
+      "region": "eu-west-3",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.46.172.0/22",
+      "region": "sa-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.65.0.0/16",
+      "region": "ap-southeast-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.93.19.236/32",
+      "region": "ap-southeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.94.200.0/24",
+      "region": "ap-northeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.119.188.0/22",
+      "region": "eu-central-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.144.194.0/26",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.150.0.0/16",
+      "region": "ap-northeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "150.222.7.0/24",
+      "region": "me-south-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "150.222.243.30/31",
+      "region": "eu-central-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "18.200.0.0/16",
+      "region": "eu-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.206.0.0/16",
+      "region": "ap-southeast-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "150.222.96.0/24",
+      "region": "eu-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "13.248.128.0/17",
+      "region": "GLOBAL",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.82.128.0/19",
+      "region": "GLOBAL",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.95.255.96/28",
+      "region": "us-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.231.128.0/19",
+      "region": "eu-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "150.222.83.0/24",
+      "region": "ap-south-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "15.197.0.0/23",
+      "region": "GLOBAL",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.226.0.0/15",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "162.250.237.0/24",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.93.149.0/24",
+      "region": "us-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.144.228.64/26",
+      "region": "ap-southeast-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.218.128.0/17",
+      "region": "us-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "76.223.0.0/17",
+      "region": "GLOBAL",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "99.84.0.0/16",
+      "region": "GLOBAL",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "15.177.86.0/24",
+      "region": "ap-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "15.221.8.0/21",
+      "region": "ap-southeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "18.144.0.0/15",
+      "region": "us-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.90.0.0/15",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.93.138.253/32",
+      "region": "eu-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.95.157.0/24",
+      "region": "ap-northeast-3",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.144.208.192/26",
+      "region": "eu-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "108.175.52.0/22",
+      "region": "us-gov-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.10.0.0/15",
+      "region": "us-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.82.164.0/22",
+      "region": "cn-northwest-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.240.230.0/23",
+      "region": "us-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "100.24.0.0/13",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "13.248.119.0/24",
+      "region": "eu-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.93.81.0/24",
+      "region": "eu-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.74.0.0/15",
+      "region": "eu-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "150.222.114.0/24",
+      "region": "ap-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "150.222.242.214/31",
+      "region": "eu-west-3",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "3.104.0.0/14",
+      "region": "ap-southeast-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "15.193.5.0/24",
+      "region": "eu-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.80.0.0/16",
+      "region": "cn-north-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.95.216.0/22",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.119.232.0/21",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.144.201.128/26",
+      "region": "ca-central-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.231.244.0/22",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "150.222.99.0/24",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "150.222.218.0/24",
+      "region": "us-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "175.41.128.0/18",
+      "region": "ap-southeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "176.32.125.250/31",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.94.32.0/20",
+      "region": "eu-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.216.0.0/15",
+      "region": "eu-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.239.0.32/28",
+      "region": "us-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.93.34.57/32",
+      "region": "us-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.94.13.0/24",
+      "region": "ap-southeast-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.78.0.0/16",
+      "region": "eu-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "99.77.139.0/24",
+      "region": "ap-northeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "99.82.160.0/24",
+      "region": "ap-south-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "204.246.160.0/22",
+      "region": "us-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "13.248.97.0/24",
+      "region": "eu-central-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "18.190.0.0/16",
+      "region": "us-east-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.82.168.0/24",
+      "region": "cn-northwest-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.222.58.48/28",
+      "region": "cn-north-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "150.222.242.84/31",
+      "region": "eu-west-3",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "162.213.232.0/24",
+      "region": "eu-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "13.248.113.0/24",
+      "region": "eu-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "15.188.0.0/16",
+      "region": "eu-west-3",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.200.0.0/15",
+      "region": "us-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.239.1.16/28",
+      "region": "eu-west-3",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "185.143.16.0/24",
+      "region": "eu-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "205.251.244.0/23",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "15.221.1.0/24",
+      "region": "us-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "150.222.210.0/24",
+      "region": "ap-south-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "13.248.0.0/20",
+      "region": "ap-northeast-3",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.95.29.0/26",
+      "region": "us-east-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "35.160.0.0/13",
+      "region": "us-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.48.0.0/14",
+      "region": "eu-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.94.198.80/28",
+      "region": "ap-south-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.231.0.0/17",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "99.77.137.0/24",
+      "region": "eu-north-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.144.192.0/26",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "150.222.112.0/24",
+      "region": "ap-southeast-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "204.236.128.0/18",
+      "region": "us-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.46.249.0/24",
+      "region": "us-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.93.20.16/32",
+      "region": "us-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.144.216.0/31",
+      "region": "eu-north-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.239.1.0/28",
+      "region": "ca-central-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "162.213.233.0/24",
+      "region": "eu-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "13.48.0.0/15",
+      "region": "eu-north-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.64.0.0/17",
+      "region": "ap-southeast-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.95.239.0/24",
+      "region": "eu-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.119.210.0/23",
+      "region": "ap-southeast-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "15.177.91.0/24",
+      "region": "af-south-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "35.155.0.0/16",
+      "region": "us-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.144.230.0/26",
+      "region": "ap-northeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.210.0.0/15",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.239.2.0/23",
+      "region": "us-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "150.222.76.0/24",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.82.169.16/28",
+      "region": "cn-northwest-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.93.34.56/32",
+      "region": "us-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.94.198.16/28",
+      "region": "sa-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.144.225.128/26",
+      "region": "ap-northeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "18.163.0.0/16",
+      "region": "ap-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.46.250.0/23",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.94.5.0/24",
+      "region": "eu-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.144.228.128/26",
+      "region": "ap-south-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.199.0.0/16",
+      "region": "ap-northeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "150.222.141.0/24",
+      "region": "ap-northeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "150.222.205.0/24",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.240.199.0/24",
+      "region": "ap-southeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.198.0.0/16",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.93.64.0/24",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.93.80.0/24",
+      "region": "eu-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.94.69.0/24",
+      "region": "eu-central-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.94.120.0/22",
+      "region": "us-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.239.40.152/29",
+      "region": "ap-northeast-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "13.248.98.0/24",
+      "region": "ap-northeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.20.0.0/14",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.94.201.0/26",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.94.248.208/28",
+      "region": "ca-central-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.219.20.0/22",
+      "region": "us-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.219.24.0/21",
+      "region": "us-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "99.82.161.0/24",
+      "region": "eu-west-3",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "204.246.172.0/24",
+      "region": "GLOBAL",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "18.142.0.0/15",
+      "region": "ap-southeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "46.137.192.0/19",
+      "region": "ap-southeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.200.0.0/13",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.219.96.0/20",
+      "region": "us-east-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.222.32.0/22",
+      "region": "cn-north-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "205.251.232.0/22",
+      "region": "us-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "13.248.116.0/24",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.76.0.0/17",
+      "region": "ap-southeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.93.48.0/24",
+      "region": "eu-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.144.216.6/31",
+      "region": "eu-north-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.240.220.0/22",
+      "region": "eu-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "15.177.82.0/24",
+      "region": "ap-southeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.144.211.196/31",
+      "region": "eu-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.219.72.0/22",
+      "region": "eu-central-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.153.128.0/17",
+      "region": "ap-southeast-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.222.58.0/28",
+      "region": "cn-north-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "122.248.192.0/18",
+      "region": "ap-southeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "150.222.119.0/24",
+      "region": "ap-southeast-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "15.230.30.0/24",
+      "region": "eu-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.144.212.64/26",
+      "region": "eu-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.207.0.0/16",
+      "region": "sa-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "99.77.145.0/24",
+      "region": "ap-south-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "15.200.0.0/16",
+      "region": "us-gov-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "35.154.0.0/16",
+      "region": "ap-south-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.82.0.0/17",
+      "region": "cn-northwest-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.94.249.32/28",
+      "region": "eu-west-3",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.239.0.160/28",
+      "region": "eu-central-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.240.227.0/24",
+      "region": "ap-southeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.94.23.0/24",
+      "region": "eu-north-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.95.48.0/22",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.219.120.0/22",
+      "region": "us-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.222.66.0/23",
+      "region": "cn-north-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.240.232.0/22",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "150.222.143.0/24",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.144.224.64/26",
+      "region": "ap-southeast-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.170.0.0/15",
+      "region": "eu-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "99.82.171.0/24",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "15.177.87.0/24",
+      "region": "me-south-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.94.4.0/24",
+      "region": "us-east-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.94.72.0/22",
+      "region": "us-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.222.48.0/22",
+      "region": "cn-north-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.240.228.0/23",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "176.32.120.0/22",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.93.69.0/24",
+      "region": "me-south-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.144.210.192/26",
+      "region": "eu-central-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.144.211.200/31",
+      "region": "eu-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.219.56.0/22",
+      "region": "ap-northeast-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.160.0.0/13",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "150.222.118.0/24",
+      "region": "eu-north-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "157.175.0.0/16",
+      "region": "me-south-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "176.34.32.0/19",
+      "region": "ap-northeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.239.108.0/22",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "150.222.133.0/24",
+      "region": "ap-northeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "18.236.0.0/15",
+      "region": "us-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.94.249.80/28",
+      "region": "us-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.240.198.0/24",
+      "region": "us-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "150.222.227.0/24",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "46.51.192.0/20",
+      "region": "eu-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.95.174.0/24",
+      "region": "me-south-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "99.77.149.0/24",
+      "region": "sa-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "99.78.156.0/22",
+      "region": "eu-central-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "150.222.220.0/24",
+      "region": "ap-south-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "15.221.16.0/22",
+      "region": "us-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.94.96.0/20",
+      "region": "ca-central-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.94.192.0/22",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "108.175.48.0/22",
+      "region": "us-gov-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.231.248.0/22",
+      "region": "ap-southeast-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "150.222.5.0/24",
+      "region": "eu-central-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "162.250.238.0/23",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "178.236.0.0/20",
+      "region": "eu-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "35.176.0.0/15",
+      "region": "eu-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.239.112.0/24",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "70.224.192.0/18",
+      "region": "us-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "150.222.105.0/24",
+      "region": "ap-northeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "3.24.0.0/14",
+      "region": "ap-southeast-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.95.34.0/24",
+      "region": "ap-northeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.144.225.0/26",
+      "region": "ap-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "150.222.13.0/24",
+      "region": "eu-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "205.251.247.0/24",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "35.153.0.0/16",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.61.0.0/16",
+      "region": "us-gov-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.79.0.0/16",
+      "region": "ap-northeast-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.93.137.0/24",
+      "region": "ap-northeast-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "150.222.89.0/24",
+      "region": "cn-north-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "15.197.4.0/22",
+      "region": "GLOBAL",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.94.16.0/24",
+      "region": "eu-west-3",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.144.195.0/26",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "13.248.105.0/24",
+      "region": "ap-south-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "18.230.0.0/16",
+      "region": "sa-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.58.0.0/15",
+      "region": "eu-central-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.218.0.0/17",
+      "region": "eu-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "150.222.176.0/22",
+      "region": "us-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.62.0.0/15",
+      "region": "ap-southeast-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.93.0.0/24",
+      "region": "eu-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.93.19.237/32",
+      "region": "ap-southeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.219.44.0/22",
+      "region": "eu-central-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.239.192.0/19",
+      "region": "GLOBAL",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "99.82.162.0/24",
+      "region": "eu-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "150.222.70.0/24",
+      "region": "sa-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "176.32.125.192/27",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "176.32.125.238/31",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "15.222.0.0/15",
+      "region": "ca-central-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.93.62.0/24",
+      "region": "us-east-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.119.248.0/24",
+      "region": "ap-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.239.0.144/28",
+      "region": "cn-north-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "15.177.73.0/24",
+      "region": "ap-south-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "46.51.216.0/21",
+      "region": "ap-southeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "176.32.125.254/31",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.28.0.0/16",
+      "region": "eu-central-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.46.166.0/23",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.46.176.0/22",
+      "region": "us-gov-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.57.0.0/16",
+      "region": "eu-central-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.94.124.0/22",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.144.211.192/31",
+      "region": "eu-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "150.222.98.0/24",
+      "region": "eu-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "150.222.101.0/24",
+      "region": "us-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "18.132.0.0/14",
+      "region": "eu-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.70.0.0/15",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.94.248.0/28",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.119.212.0/23",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.144.216.10/31",
+      "region": "eu-north-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.239.99.0/24",
+      "region": "eu-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "108.166.224.0/21",
+      "region": "us-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.29.0.0/16",
+      "region": "eu-central-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.94.15.0/24",
+      "region": "eu-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.95.35.0/24",
+      "region": "ap-southeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.95.62.0/24",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.95.144.0/24",
+      "region": "us-gov-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.144.194.64/26",
+      "region": "us-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.144.209.0/26",
+      "region": "eu-central-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.239.1.83/32",
+      "region": "ap-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "15.177.70.0/23",
+      "region": "sa-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "15.236.0.0/15",
+      "region": "eu-west-3",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.144.211.198/31",
+      "region": "eu-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "99.77.254.0/24",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "184.72.0.0/18",
+      "region": "us-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.95.246.0/24",
+      "region": "us-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.144.215.2/31",
+      "region": "eu-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "99.83.64.0/21",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "15.177.83.0/24",
+      "region": "ap-southeast-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "15.185.0.0/16",
+      "region": "me-south-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.93.35.212/32",
+      "region": "ap-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.94.26.0/23",
+      "region": "eu-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.247.0.0/16",
+      "region": "eu-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.248.0.0/15",
+      "region": "ap-northeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "27.0.0.0/22",
+      "region": "ap-northeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.46.180.0/22",
+      "region": "us-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.93.98.0/24",
+      "region": "ap-south-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.93.146.5/32",
+      "region": "sa-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.93.1.0/24",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.94.30.0/24",
+      "region": "af-south-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.93.73.0/26",
+      "region": "ap-northeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.94.198.144/28",
+      "region": "eu-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.94.208.0/21",
+      "region": "us-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.95.227.0/24",
+      "region": "eu-north-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.68.0.0/14",
+      "region": "us-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.93.0.0/16",
+      "region": "eu-central-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "70.132.0.0/18",
+      "region": "GLOBAL",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "13.248.120.0/24",
+      "region": "eu-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.54.0.0/15",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.93.3.0/24",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.95.230.0/24",
+      "region": "us-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.240.225.0/24",
+      "region": "ap-northeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "99.78.212.0/22",
+      "region": "ap-southeast-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "150.222.106.0/24",
+      "region": "us-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "18.182.0.0/16",
+      "region": "ap-northeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.152.0.0/16",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "176.32.125.240/31",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "13.32.0.0/15",
+      "region": "GLOBAL",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "13.112.0.0/14",
+      "region": "ap-northeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.68.0.0/15",
+      "region": "ap-northeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.144.231.64/26",
+      "region": "ap-southeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.67.0.0/16",
+      "region": "us-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "99.82.173.0/24",
+      "region": "ap-southeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "15.177.0.0/18",
+      "region": "GLOBAL",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "18.194.0.0/15",
+      "region": "eu-central-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.46.64.0/20",
+      "region": "eu-west-3",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.94.197.0/24",
+      "region": "us-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.94.249.128/28",
+      "region": "eu-north-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.144.193.64/26",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.184.0.0/13",
+      "region": "us-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.239.16.0/20",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "99.82.163.0/24",
+      "region": "eu-central-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "3.13.0.0/16",
+      "region": "us-east-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "3.248.0.0/13",
+      "region": "eu-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.92.128.0/17",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.239.0.0/28",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "99.77.133.0/24",
+      "region": "eu-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "150.222.233.0/24",
+      "region": "us-east-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.0.0.0/15",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.82.184.0/23",
+      "region": "cn-northwest-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.93.250.0/23",
+      "region": "ap-northeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.95.176.0/24",
+      "region": "af-south-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.95.253.0/24",
+      "region": "eu-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.239.120.0/21",
+      "region": "ap-northeast-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "140.179.0.0/16",
+      "region": "cn-north-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "150.222.234.0/24",
+      "region": "us-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "205.251.208.0/20",
+      "region": "GLOBAL",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "3.5.132.0/23",
+      "region": "us-east-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "13.53.0.0/16",
+      "region": "eu-north-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "13.248.114.0/24",
+      "region": "sa-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "15.177.88.0/24",
+      "region": "sa-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.94.48.0/20",
+      "region": "eu-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "99.78.188.0/22",
+      "region": "ap-northeast-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "184.72.128.0/17",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "205.251.248.0/24",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "13.224.0.0/14",
+      "region": "GLOBAL",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.119.240.0/21",
+      "region": "eu-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.239.0.80/28",
+      "region": "ap-northeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.240.216.0/22",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "99.82.128.0/20",
+      "region": "me-south-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "99.82.166.0/24",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "13.58.0.0/15",
+      "region": "us-east-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.93.51.29/32",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.194.0.0/15",
+      "region": "eu-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.240.244.0/22",
+      "region": "sa-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "150.222.102.0/24",
+      "region": "us-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "35.156.0.0/14",
+      "region": "eu-central-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.93.18.178/32",
+      "region": "eu-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.144.209.64/26",
+      "region": "eu-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "23.20.0.0/14",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.46.168.0/23",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.93.151.0/24",
+      "region": "sa-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.94.248.80/28",
+      "region": "ap-northeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "64.252.64.0/24",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "99.77.143.0/24",
+      "region": "ap-southeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.92.16.0/20",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.93.67.0/24",
+      "region": "sa-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.95.64.0/20",
+      "region": "ap-south-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.95.225.0/24",
+      "region": "ap-northeast-3",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "150.222.11.0/31",
+      "region": "eu-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "172.96.97.0/24",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "18.229.0.0/16",
+      "region": "sa-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.94.68.0/24",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.95.192.0/20",
+      "region": "ap-northeast-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.219.0.0/16",
+      "region": "us-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "150.222.243.48/31",
+      "region": "eu-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "18.204.0.0/14",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "35.178.0.0/15",
+      "region": "eu-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.94.9.0/24",
+      "region": "us-gov-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.94.204.0/23",
+      "region": "eu-central-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.88.0.0/14",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "75.2.0.0/17",
+      "region": "GLOBAL",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "99.78.192.0/22",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.12.0.0/15",
+      "region": "us-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.220.0.0/15",
+      "region": "ap-southeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.231.252.0/24",
+      "region": "ap-southeast-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.239.1.128/28",
+      "region": "af-south-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "162.250.236.0/24",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "13.35.0.0/16",
+      "region": "GLOBAL",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "34.240.0.0/13",
+      "region": "eu-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.93.14.19/32",
+      "region": "us-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.94.248.16/28",
+      "region": "eu-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.94.249.96/28",
+      "region": "ap-northeast-3",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.144.216.8/31",
+      "region": "eu-north-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.239.1.81/32",
+      "region": "ap-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.240.200.0/24",
+      "region": "ap-northeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.253.0.0/16",
+      "region": "ap-southeast-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "18.166.0.0/15",
+      "region": "ap-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.46.240.0/22",
+      "region": "eu-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.94.28.0/23",
+      "region": "us-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.94.248.128/28",
+      "region": "us-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.239.100.0/23",
+      "region": "eu-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "99.77.250.0/24",
+      "region": "eu-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "150.222.214.0/24",
+      "region": "us-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "176.32.125.248/31",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.94.248.64/28",
+      "region": "ap-southeast-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.95.229.0/24",
+      "region": "af-south-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.72.0.0/15",
+      "region": "eu-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.239.0.192/28",
+      "region": "ap-northeast-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.94.11.0/24",
+      "region": "ap-southeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.144.200.128/26",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.240.196.0/24",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "150.222.66.0/24",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "204.246.164.0/22",
+      "region": "GLOBAL",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.223.0.0/16",
+      "region": "cn-north-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.239.0.48/28",
+      "region": "eu-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.239.64.0/21",
+      "region": "eu-central-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "99.77.129.0/24",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "15.177.89.0/24",
+      "region": "eu-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "18.156.0.0/14",
+      "region": "eu-central-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.95.24.0/22",
+      "region": "us-east-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.119.196.0/22",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.144.218.64/26",
+      "region": "eu-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "79.125.0.0/17",
+      "region": "eu-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "99.77.134.0/24",
+      "region": "eu-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "99.78.144.0/21",
+      "region": "af-south-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.88.0.0/15",
+      "region": "us-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "3.131.0.0/16",
+      "region": "us-east-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.219.0.0/20",
+      "region": "ap-northeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.240.248.0/21",
+      "region": "us-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "176.32.125.252/31",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.93.75.0/24",
+      "region": "ca-central-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.94.248.32/28",
+      "region": "ap-southeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.219.40.0/22",
+      "region": "ap-southeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.219.136.0/22",
+      "region": "ap-northeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.220.0.0/16",
+      "region": "eu-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "100.20.0.0/14",
+      "region": "us-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "150.222.74.0/24",
+      "region": "us-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "176.32.125.236/31",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "13.248.56.0/22",
+      "region": "ap-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "13.248.117.0/24",
+      "region": "ap-south-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.94.24.0/23",
+      "region": "eu-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "150.222.199.0/25",
+      "region": "us-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "3.8.0.0/14",
+      "region": "eu-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "13.248.60.0/22",
+      "region": "ap-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "18.246.0.0/16",
+      "region": "us-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.93.139.252/32",
+      "region": "eu-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.94.198.0/28",
+      "region": "us-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.204.0.0/15",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "150.222.67.0/24",
+      "region": "eu-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.95.163.0/24",
+      "region": "sa-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "99.78.220.0/22",
+      "region": "me-south-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "216.182.236.0/23",
+      "region": "us-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "34.208.0.0/12",
+      "region": "us-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.15.0.0/16",
+      "region": "us-east-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.144.209.128/26",
+      "region": "eu-west-3",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "150.222.224.0/24",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "18.162.0.0/16",
+      "region": "ap-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.95.30.0/23",
+      "region": "ap-northeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.95.96.0/22",
+      "region": "ap-south-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.95.145.0/24",
+      "region": "ca-central-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "176.32.125.246/31",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "15.177.64.0/23",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.86.0.0/15",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "150.222.180.0/24",
+      "region": "us-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.44.0.0/15",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.76.128.0/17",
+      "region": "ap-southeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.92.40.0/21",
+      "region": "eu-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.219.32.0/21",
+      "region": "ap-southeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.95.0.0/16",
+      "region": "ap-northeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.212.0.0/15",
+      "region": "us-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "150.222.69.0/24",
+      "region": "sa-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "18.232.0.0/14",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.82.169.0/28",
+      "region": "cn-northwest-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.93.112.0/24",
+      "region": "eu-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.239.0.224/28",
+      "region": "us-east-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.239.48.0/22",
+      "region": "us-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.47.0.0/16",
+      "region": "eu-west-3",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.93.16.0/24",
+      "region": "eu-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.94.249.144/28",
+      "region": "ap-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.95.136.0/23",
+      "region": "sa-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.95.255.64/28",
+      "region": "eu-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.144.199.128/26",
+      "region": "ca-central-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.144.225.64/26",
+      "region": "ap-northeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.219.48.0/22",
+      "region": "ap-southeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "204.246.168.0/22",
+      "region": "GLOBAL",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.219.62.0/23",
+      "region": "ap-south-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "99.77.147.0/24",
+      "region": "me-south-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.93.254.0/24",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.95.175.0/24",
+      "region": "af-south-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "99.82.175.0/24",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "162.213.234.0/23",
+      "region": "eu-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "3.132.0.0/14",
+      "region": "us-east-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.46.208.0/21",
+      "region": "eu-north-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.93.51.28/32",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.94.12.0/24",
+      "region": "us-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "63.32.0.0/14",
+      "region": "eu-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.83.0.0/16",
+      "region": "cn-northwest-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.93.14.18/32",
+      "region": "us-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.94.6.0/24",
+      "region": "ap-northeast-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.144.197.192/26",
+      "region": "us-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "150.222.2.0/24",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.79.0.0/16",
+      "region": "ap-southeast-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.251.0.0/16",
+      "region": "ap-southeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "150.222.206.0/24",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "18.189.0.0/16",
+      "region": "us-east-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.95.52.0/22",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "18.153.0.0/16",
+      "region": "eu-central-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "18.202.0.0/15",
+      "region": "eu-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.239.1.48/28",
+      "region": "ap-northeast-3",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "176.32.104.0/21",
+      "region": "eu-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "3.20.0.0/14",
+      "region": "us-east-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "18.196.0.0/15",
+      "region": "eu-central-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.76.0.0/15",
+      "region": "eu-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "205.251.192.0/21",
+      "region": "GLOBAL",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.94.80.0/20",
+      "region": "ca-central-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.94.198.112/28",
+      "region": "ap-southeast-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.240.197.0/24",
+      "region": "eu-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "71.152.0.0/17",
+      "region": "GLOBAL",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "108.166.232.0/21",
+      "region": "us-east-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "216.137.32.0/19",
+      "region": "GLOBAL",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.46.252.0/22",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.95.255.16/28",
+      "region": "ap-southeast-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "13.232.0.0/14",
+      "region": "ap-south-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.95.243.0/24",
+      "region": "ap-northeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "13.248.109.0/24",
+      "region": "ap-southeast-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "15.177.80.0/24",
+      "region": "us-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.144.224.192/26",
+      "region": "ap-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.219.80.0/20",
+      "region": "us-east-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.174.0.0/15",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "150.222.78.0/24",
+      "region": "ap-southeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "15.221.4.0/23",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.144.211.64/26",
+      "region": "eu-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "150.222.109.0/24",
+      "region": "ca-central-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "50.16.0.0/15",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.95.208.0/22",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "150.222.84.0/24",
+      "region": "ap-south-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "150.222.243.22/31",
+      "region": "eu-central-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "205.251.249.0/24",
+      "region": "GLOBAL",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "13.248.115.0/24",
+      "region": "ap-northeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.52.0.0/15",
+      "region": "us-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.144.197.128/26",
+      "region": "us-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.233.64.0/18",
+      "region": "sa-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "35.168.0.0/13",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.64.128.0/17",
+      "region": "ap-southeast-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.93.248.0/24",
+      "region": "ap-northeast-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.94.198.48/28",
+      "region": "eu-central-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.95.228.0/24",
+      "region": "me-south-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.222.128.0/17",
+      "region": "cn-north-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "96.127.0.0/17",
+      "region": "us-gov-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.119.252.0/22",
+      "region": "us-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.148.0.0/15",
+      "region": "us-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "99.77.130.0/24",
+      "region": "us-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "35.182.0.0/15",
+      "region": "ca-central-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "99.77.191.0/24",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "3.112.0.0/14",
+      "region": "ap-northeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.95.244.0/24",
+      "region": "eu-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "99.82.188.0/22",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.95.148.0/23",
+      "region": "eu-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "3.208.0.0/12",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "15.221.0.0/24",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.92.88.0/22",
+      "region": "eu-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.222.64.0/23",
+      "region": "cn-north-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "185.48.120.0/22",
+      "region": "eu-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "3.5.0.0/20",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.144.192.64/26",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.240.192.0/22",
+      "region": "ap-southeast-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "150.222.97.0/24",
+      "region": "us-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "15.221.24.0/21",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "18.220.0.0/14",
+      "region": "us-east-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.36.0.0/14",
+      "region": "us-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.94.112.0/22",
+      "region": "eu-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.94.0.0/16",
+      "region": "sa-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "99.78.184.0/22",
+      "region": "ap-northeast-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "150.222.207.0/24",
+      "region": "eu-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "150.222.237.0/24",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "15.230.29.0/24",
+      "region": "ap-southeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "18.191.0.0/16",
+      "region": "us-east-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.144.210.0/26",
+      "region": "eu-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.95.169.0/24",
+      "region": "eu-north-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.222.0.0/19",
+      "region": "cn-north-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.239.0.112/28",
+      "region": "ap-southeast-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.239.8.0/21",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.240.204.0/22",
+      "region": "ap-southeast-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "99.86.0.0/16",
+      "region": "GLOBAL",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "207.171.176.0/20",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "18.178.0.0/16",
+      "region": "ap-northeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.95.164.0/23",
+      "region": "sa-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.144.208.128/26",
+      "region": "eu-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.144.213.64/26",
+      "region": "eu-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.202.0.0/15",
+      "region": "us-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.240.208.0/22",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "150.222.204.0/24",
+      "region": "eu-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "3.128.0.0/15",
+      "region": "us-east-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "13.248.107.0/24",
+      "region": "ap-southeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.94.240.0/22",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.144.210.64/26",
+      "region": "eu-west-3",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "150.222.138.0/24",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "13.248.104.0/24",
+      "region": "sa-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "34.248.0.0/13",
+      "region": "eu-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.93.237.0/24",
+      "region": "us-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "15.206.0.0/15",
+      "region": "ap-south-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "50.18.0.0/16",
+      "region": "us-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.14.0.0/16",
+      "region": "us-east-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.46.0.0/18",
+      "region": "GLOBAL",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.46.88.0/22",
+      "region": "eu-west-3",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "3.12.0.0/16",
+      "region": "us-east-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "13.124.0.0/16",
+      "region": "ap-northeast-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.84.0.0/15",
+      "region": "GLOBAL",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.93.122.131/32",
+      "region": "us-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.94.248.144/28",
+      "region": "ap-south-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.192.0.0/15",
+      "region": "ap-northeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "150.222.110.0/24",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.95.255.32/28",
+      "region": "ap-southeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.144.229.0/26",
+      "region": "ap-southeast-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "160.1.0.0/16",
+      "region": "us-gov-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "13.236.0.0/14",
+      "region": "ap-southeast-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.46.220.0/22",
+      "region": "eu-north-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.92.32.0/22",
+      "region": "us-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.93.56.0/24",
+      "region": "eu-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.95.41.0/24",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.95.100.0/22",
+      "region": "us-gov-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.95.226.0/24",
+      "region": "ap-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "99.78.152.0/22",
+      "region": "af-south-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "150.222.135.0/24",
+      "region": "ap-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "150.222.202.0/24",
+      "region": "eu-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "176.32.125.244/31",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.95.172.0/23",
+      "region": "me-south-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "174.129.0.0/16",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "13.209.0.0/16",
+      "region": "ap-northeast-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "18.140.0.0/15",
+      "region": "ap-southeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.60.0.0/16",
+      "region": "ca-central-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.78.0.0/16",
+      "region": "ap-northeast-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "72.44.32.0/19",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "205.251.236.0/22",
+      "region": "us-gov-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "34.224.0.0/12",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.75.0.0/16",
+      "region": "us-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.82.160.0/22",
+      "region": "cn-northwest-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.144.215.194/31",
+      "region": "eu-north-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "99.78.128.0/20",
+      "region": "af-south-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "99.82.164.0/24",
+      "region": "sa-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.92.68.0/22",
+      "region": "eu-central-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.94.0.0/22",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "205.251.240.0/22",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "13.230.0.0/15",
+      "region": "ap-northeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "13.248.111.0/24",
+      "region": "us-east-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.93.4.0/24",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.93.59.0/24",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.94.198.96/28",
+      "region": "ap-southeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.94.249.160/28",
+      "region": "me-south-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.144.194.128/26",
+      "region": "us-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.144.210.128/26",
+      "region": "eu-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.144.211.202/31",
+      "region": "eu-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.219.112.0/21",
+      "region": "us-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.224.0.0/15",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.239.32.0/21",
+      "region": "eu-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "15.164.0.0/15",
+      "region": "ap-northeast-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.46.96.0/19",
+      "region": "us-gov-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.46.128.0/19",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.239.0.128/28",
+      "region": "us-gov-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "176.32.125.242/31",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "176.34.128.0/17",
+      "region": "eu-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.95.240.0/24",
+      "region": "sa-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.219.16.0/22",
+      "region": "ap-northeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "75.101.128.0/17",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "176.32.125.234/31",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "204.246.173.0/24",
+      "region": "GLOBAL",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.46.164.0/23",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.178.0.0/16",
+      "region": "ap-northeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "99.82.168.0/24",
+      "region": "ap-northeast-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "108.128.0.0/13",
+      "region": "eu-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "150.222.221.0/24",
+      "region": "us-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.95.61.0/24",
+      "region": "eu-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.219.124.0/22",
+      "region": "ap-southeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.240.241.0/24",
+      "region": "ap-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "130.176.0.0/16",
+      "region": "GLOBAL",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "150.222.235.0/24",
+      "region": "ap-south-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "176.32.125.232/31",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "13.56.0.0/16",
+      "region": "us-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "18.184.0.0/15",
+      "region": "eu-central-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "72.21.192.0/19",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "205.251.200.0/21",
+      "region": "GLOBAL",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.93.57.0/24",
+      "region": "af-south-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.95.63.0/24",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.94.252.0/23",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.144.215.198/31",
+      "region": "eu-north-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.222.57.0/24",
+      "region": "cn-north-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "99.83.128.0/17",
+      "region": "GLOBAL",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "3.5.128.0/22",
+      "region": "us-east-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "15.230.21.0/24",
+      "region": "ca-central-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "18.216.0.0/14",
+      "region": "us-east-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "34.192.0.0/12",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.93.37.222/32",
+      "region": "us-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.94.64.0/22",
+      "region": "ca-central-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.231.160.0/19",
+      "region": "us-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "13.248.112.0/24",
+      "region": "us-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.239.115.0/25",
+      "region": "eu-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.93.18.179/32",
+      "region": "eu-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.94.196.0/24",
+      "region": "eu-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.215.0.0/16",
+      "region": "us-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "15.177.68.0/23",
+      "region": "eu-central-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "177.71.128.0/17",
+      "region": "sa-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "18.175.0.0/16",
+      "region": "eu-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.46.216.0/22",
+      "region": "us-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.92.76.0/22",
+      "region": "us-east-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.208.0.0/15",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.228.0.0/16",
+      "region": "eu-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.92.52.0/22",
+      "region": "ap-southeast-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.93.247.0/25",
+      "region": "ap-northeast-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "18.192.0.0/15",
+      "region": "eu-central-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.92.60.0/22",
+      "region": "ap-northeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.144.215.192/31",
+      "region": "eu-north-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.219.68.0/22",
+      "region": "ap-northeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.229.0.0/16",
+      "region": "eu-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.239.1.96/28",
+      "region": "eu-north-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.94.14.0/24",
+      "region": "ca-central-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.94.198.64/28",
+      "region": "ap-northeast-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.119.216.0/21",
+      "region": "ap-northeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "15.230.22.0/24",
+      "region": "ap-southeast-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "18.138.0.0/15",
+      "region": "ap-southeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.95.255.144/28",
+      "region": "cn-north-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "204.246.174.0/23",
+      "region": "GLOBAL",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "3.120.0.0/14",
+      "region": "eu-central-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "18.198.0.0/15",
+      "region": "eu-central-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.9.0.0/16",
+      "region": "us-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.93.38.0/24",
+      "region": "eu-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.144.216.4/31",
+      "region": "eu-north-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.219.128.0/22",
+      "region": "ap-southeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "99.77.141.0/24",
+      "region": "ap-northeast-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "150.222.196.0/24",
+      "region": "us-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "13.244.0.0/15",
+      "region": "af-south-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.94.248.48/28",
+      "region": "sa-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.242.0.0/15",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "177.72.240.0/21",
+      "region": "sa-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "216.182.238.0/23",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "35.180.0.0/16",
+      "region": "eu-west-3",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.94.76.0/22",
+      "region": "us-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.95.36.0/22",
+      "region": "ap-southeast-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "150.222.81.0/24",
+      "region": "eu-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "3.14.0.0/15",
+      "region": "us-east-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "15.177.81.0/24",
+      "region": "us-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "18.228.0.0/16",
+      "region": "sa-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.16.0.0/15",
+      "region": "eu-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.95.28.0/24",
+      "region": "us-east-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.95.146.0/23",
+      "region": "ca-central-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.95.242.0/24",
+      "region": "ap-southeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.144.212.192/26",
+      "region": "eu-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "161.189.0.0/16",
+      "region": "cn-northwest-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "13.52.0.0/16",
+      "region": "us-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "18.180.0.0/15",
+      "region": "ap-northeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "46.137.128.0/18",
+      "region": "eu-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.93.2.0/24",
+      "region": "eu-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.94.248.176/28",
+      "region": "ap-northeast-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.93.245.0/24",
+      "region": "ap-northeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.95.16.0/21",
+      "region": "us-east-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.234.0.0/15",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "18.188.0.0/16",
+      "region": "us-east-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "18.252.0.0/16",
+      "region": "us-gov-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "46.51.128.0/18",
+      "region": "eu-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "64.252.128.0/18",
+      "region": "GLOBAL",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "99.82.152.0/22",
+      "region": "me-south-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "99.82.167.0/24",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "150.222.108.0/24",
+      "region": "ap-southeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "176.32.125.128/26",
+      "region": "us-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "205.251.254.0/24",
+      "region": "GLOBAL",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "15.177.84.0/24",
+      "region": "ca-central-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.94.249.176/28",
+      "region": "af-south-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.94.254.0/23",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.153.0.0/17",
+      "region": "us-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "150.222.243.24/31",
+      "region": "eu-central-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "15.177.75.0/24",
+      "region": "eu-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "15.230.24.0/22",
+      "region": "ap-northeast-3",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.24.0.0/14",
+      "region": "us-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.46.170.0/23",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.95.56.0/22",
+      "region": "ap-northeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.119.160.0/20",
+      "region": "us-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.222.0.0/17",
+      "region": "us-gov-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "64.252.65.0/24",
+      "region": "us-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.82.192.0/18",
+      "region": "cn-northwest-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.93.12.13/32",
+      "region": "us-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.239.96.0/24",
+      "region": "ap-northeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.240.226.0/24",
+      "region": "ap-southeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "99.78.216.0/22",
+      "region": "us-east-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "150.222.75.0/24",
+      "region": "us-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "176.32.125.224/31",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "15.177.66.0/23",
+      "region": "us-east-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.94.248.224/28",
+      "region": "us-gov-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.95.162.0/24",
+      "region": "ap-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.95.255.48/28",
+      "region": "ap-northeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.218.0.0/16",
+      "region": "us-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "150.222.215.0/24",
+      "region": "eu-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "3.124.0.0/14",
+      "region": "eu-central-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.82.176.0/22",
+      "region": "cn-northwest-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.144.194.192/26",
+      "region": "us-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.183.0.0/16",
+      "region": "us-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "13.248.101.0/24",
+      "region": "eu-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.95.255.0/28",
+      "region": "sa-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.176.0.0/15",
+      "region": "us-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.246.0.0/16",
+      "region": "eu-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "13.248.108.0/24",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.95.108.0/23",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.144.193.0/26",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "99.78.168.0/23",
+      "region": "eu-central-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "108.166.248.0/21",
+      "region": "us-east-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "143.204.0.0/16",
+      "region": "GLOBAL",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "150.222.91.0/24",
+      "region": "ap-northeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "15.230.18.0/24",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "18.231.0.0/16",
+      "region": "sa-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.252.0.0/16",
+      "region": "ap-southeast-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "150.222.79.0/24",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "46.137.224.0/19",
+      "region": "ap-southeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.92.248.0/22",
+      "region": "ap-south-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.95.42.0/24",
+      "region": "us-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "99.82.156.0/22",
+      "region": "GLOBAL",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "13.248.32.0/20",
+      "region": "ap-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.94.199.0/24",
+      "region": "us-east-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.95.128.0/21",
+      "region": "ap-southeast-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.119.206.0/23",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "176.32.125.230/31",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "205.251.252.0/23",
+      "region": "GLOBAL",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.119.176.0/21",
+      "region": "us-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.144.0.0/14",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.169.0.0/16",
+      "region": "ap-southeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "99.77.136.0/24",
+      "region": "eu-central-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.66.0.0/16",
+      "region": "ap-southeast-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "150.222.236.0/24",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "3.5.212.0/23",
+      "region": "ap-south-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "15.177.72.0/24",
+      "region": "eu-north-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.2.0.0/15",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "103.4.8.0/21",
+      "region": "ap-northeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "176.32.96.0/21",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "184.72.64.0/18",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "15.193.3.0/24",
+      "region": "ap-southeast-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.94.244.0/22",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.119.208.0/23",
+      "region": "us-gov-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "150.222.228.0/24",
+      "region": "sa-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.93.150.0/24",
+      "region": "ap-northeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.95.112.0/20",
+      "region": "eu-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "99.78.196.0/22",
+      "region": "us-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "18.179.0.0/16",
+      "region": "ap-northeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.93.156.0/22",
+      "region": "ap-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.95.138.0/24",
+      "region": "sa-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "205.251.224.0/22",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.95.110.0/24",
+      "region": "GLOBAL",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "150.222.115.0/24",
+      "region": "ap-south-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "46.51.224.0/19",
+      "region": "ap-northeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.95.111.0/24",
+      "region": "ap-northeast-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.179.0.0/16",
+      "region": "ap-southeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.240.203.0/24",
+      "region": "ap-southeast-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "150.222.134.0/24",
+      "region": "eu-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.233.0.0/18",
+      "region": "sa-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "99.82.172.0/24",
+      "region": "us-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "150.222.82.0/24",
+      "region": "ap-southeast-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "150.222.243.20/31",
+      "region": "eu-central-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.119.184.0/22",
+      "region": "ap-southeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.144.211.194/31",
+      "region": "eu-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.239.104.0/23",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "204.246.176.0/20",
+      "region": "GLOBAL",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.8.0.0/16",
+      "region": "us-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.95.247.0/24",
+      "region": "us-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "15.177.78.0/24",
+      "region": "eu-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "15.193.0.0/24",
+      "region": "ap-south-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.66.0.0/16",
+      "region": "ap-south-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.239.0.64/28",
+      "region": "sa-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "99.82.176.0/21",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "204.236.192.0/18",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "15.177.79.0/24",
+      "region": "ap-northeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.95.160.0/23",
+      "region": "ap-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.64.0.0/15",
+      "region": "ap-northeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "103.8.172.0/22",
+      "region": "ap-southeast-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "176.34.0.0/19",
+      "region": "ap-northeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "13.248.96.0/24",
+      "region": "eu-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.95.158.0/23",
+      "region": "ap-northeast-3",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.144.192.128/26",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.216.0.0/15",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "99.82.144.0/21",
+      "region": "me-south-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "99.82.169.0/24",
+      "region": "eu-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "150.222.80.0/24",
+      "region": "eu-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "15.230.28.0/24",
+      "region": "us-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.94.198.128/28",
+      "region": "ca-central-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.95.248.0/24",
+      "region": "eu-central-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.239.0.176/28",
+      "region": "cn-northwest-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.46.92.0/22",
+      "region": "eu-west-3",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.93.236.0/24",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.239.98.0/24",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "176.32.125.228/31",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.82.188.0/22",
+      "region": "cn-northwest-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.222.58.32/28",
+      "region": "cn-north-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "176.32.125.0/25",
+      "region": "us-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "13.249.0.0/16",
+      "region": "GLOBAL",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "15.193.6.0/24",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "13.248.28.0/22",
+      "region": "ap-northeast-3",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "18.176.0.0/15",
+      "region": "ap-northeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.239.56.0/21",
+      "region": "eu-central-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "99.82.165.0/24",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "3.0.0.0/15",
+      "region": "ap-southeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "13.248.102.0/24",
+      "region": "ap-southeast-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "43.250.193.0/24",
+      "region": "ap-southeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.77.0.0/16",
+      "region": "ap-southeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.93.21.15/32",
+      "region": "eu-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.119.205.0/24",
+      "region": "ap-southeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.144.227.64/26",
+      "region": "ap-northeast-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.239.1.64/28",
+      "region": "us-gov-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "18.224.0.0/14",
+      "region": "us-east-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.56.0.0/16",
+      "region": "eu-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.240.212.0/22",
+      "region": "us-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.245.0.0/16",
+      "region": "us-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "150.222.100.0/24",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "43.250.192.0/24",
+      "region": "ap-southeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.239.113.0/24",
+      "region": "eu-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "176.32.112.0/21",
+      "region": "us-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "13.248.121.0/24",
+      "region": "eu-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.94.10.0/24",
+      "region": "us-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "99.82.170.0/24",
+      "region": "ap-northeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.94.7.0/24",
+      "region": "sa-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.95.60.0/24",
+      "region": "eu-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "13.248.16.0/21",
+      "region": "ap-northeast-3",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.240.128.0/18",
+      "region": "GLOBAL",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "150.222.12.0/24",
+      "region": "sa-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "150.222.116.0/24",
+      "region": "ap-northeast-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "205.251.250.0/23",
+      "region": "GLOBAL",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.144.200.64/26",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.144.211.128/26",
+      "region": "eu-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "99.77.131.0/24",
+      "region": "us-east-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "15.177.85.0/24",
+      "region": "ap-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.95.251.0/24",
+      "region": "us-east-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.4.0.0/14",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.144.227.192/26",
+      "region": "ap-northeast-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.144.229.64/26",
+      "region": "ap-northeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "3.6.0.0/15",
+      "region": "ap-south-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "15.193.1.0/24",
+      "region": "ap-northeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.46.80.0/21",
+      "region": "eu-west-3",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.46.184.0/22",
+      "region": "eu-central-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.67.0.0/16",
+      "region": "sa-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.93.43.0/24",
+      "region": "eu-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.93.78.0/24",
+      "region": "ap-southeast-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.239.116.0/22",
+      "region": "ap-northeast-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "18.201.0.0/16",
+      "region": "eu-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.119.214.0/23",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.144.215.202/31",
+      "region": "eu-north-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.151.128.0/17",
+      "region": "ap-southeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "208.86.88.0/23",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "44.224.0.0/11",
+      "region": "us-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.81.0.0/16",
+      "region": "cn-north-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.222.128.0/17",
+      "region": "GLOBAL",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "150.222.104.0/24",
+      "region": "eu-central-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "13.250.0.0/15",
+      "region": "ap-southeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "44.192.0.0/11",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.95.166.0/23",
+      "region": "us-gov-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.144.216.2/31",
+      "region": "eu-north-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "3.16.0.0/14",
+      "region": "us-east-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "18.130.0.0/16",
+      "region": "eu-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.72.0.0/15",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.82.180.0/22",
+      "region": "cn-northwest-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.93.35.213/32",
+      "region": "ap-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.182.0.0/16",
+      "region": "GLOBAL",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.95.168.0/24",
+      "region": "us-gov-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.144.224.128/26",
+      "region": "ap-southeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.192.0.0/16",
+      "region": "GLOBAL",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.239.0.16/28",
+      "region": "us-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.239.0.96/28",
+      "region": "ap-southeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "99.77.148.0/24",
+      "region": "af-south-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "18.136.0.0/16",
+      "region": "ap-southeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "50.112.0.0/16",
+      "region": "us-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.93.97.0/24",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.144.215.0/31",
+      "region": "eu-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.144.215.196/31",
+      "region": "eu-north-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "87.238.80.0/21",
+      "region": "eu-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.95.255.80/28",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "150.222.87.0/24",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.92.252.0/22",
+      "region": "us-gov-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.95.250.0/24",
+      "region": "ca-central-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.144.211.0/26",
+      "region": "eu-central-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "50.19.0.0/16",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "99.79.0.0/16",
+      "region": "ca-central-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "150.222.73.0/24",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "3.130.0.0/16",
+      "region": "us-east-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "13.57.0.0/16",
+      "region": "us-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "13.126.0.0/15",
+      "region": "ap-south-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.239.4.0/22",
+      "region": "eu-central-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "99.77.140.0/24",
+      "region": "ap-northeast-3",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.93.63.0/24",
+      "region": "ap-southeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.172.0.0/15",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "150.222.239.0/24",
+      "region": "eu-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "176.34.64.0/18",
+      "region": "eu-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "52.94.206.0/23",
+      "region": "sa-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.231.192.0/20",
+      "region": "eu-central-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.233.128.0/17",
+      "region": "sa-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "203.83.220.0/22",
+      "region": "ap-southeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.245.168.0/26",
+      "region": "us-west-2",
+      "service": "ROUTE53_HEALTHCHECKS"
+    },
+    {
+      "ip_prefix": "54.243.31.192/26",
+      "region": "us-east-1",
+      "service": "ROUTE53_HEALTHCHECKS"
+    },
+    {
+      "ip_prefix": "177.71.207.128/26",
+      "region": "sa-east-1",
+      "service": "ROUTE53_HEALTHCHECKS"
+    },
+    {
+      "ip_prefix": "54.255.254.192/26",
+      "region": "ap-southeast-1",
+      "service": "ROUTE53_HEALTHCHECKS"
+    },
+    {
+      "ip_prefix": "15.177.0.0/18",
+      "region": "GLOBAL",
+      "service": "ROUTE53_HEALTHCHECKS"
+    },
+    {
+      "ip_prefix": "54.244.52.192/26",
+      "region": "us-west-2",
+      "service": "ROUTE53_HEALTHCHECKS"
+    },
+    {
+      "ip_prefix": "176.34.159.192/26",
+      "region": "eu-west-1",
+      "service": "ROUTE53_HEALTHCHECKS"
+    },
+    {
+      "ip_prefix": "54.251.31.128/26",
+      "region": "ap-southeast-1",
+      "service": "ROUTE53_HEALTHCHECKS"
+    },
+    {
+      "ip_prefix": "54.183.255.128/26",
+      "region": "us-west-1",
+      "service": "ROUTE53_HEALTHCHECKS"
+    },
+    {
+      "ip_prefix": "54.241.32.64/26",
+      "region": "us-west-1",
+      "service": "ROUTE53_HEALTHCHECKS"
+    },
+    {
+      "ip_prefix": "54.252.254.192/26",
+      "region": "ap-southeast-2",
+      "service": "ROUTE53_HEALTHCHECKS"
+    },
+    {
+      "ip_prefix": "107.23.255.0/26",
+      "region": "us-east-1",
+      "service": "ROUTE53_HEALTHCHECKS"
+    },
+    {
+      "ip_prefix": "54.248.220.0/26",
+      "region": "ap-northeast-1",
+      "service": "ROUTE53_HEALTHCHECKS"
+    },
+    {
+      "ip_prefix": "54.228.16.0/26",
+      "region": "eu-west-1",
+      "service": "ROUTE53_HEALTHCHECKS"
+    },
+    {
+      "ip_prefix": "54.250.253.192/26",
+      "region": "ap-northeast-1",
+      "service": "ROUTE53_HEALTHCHECKS"
+    },
+    {
+      "ip_prefix": "54.232.40.64/26",
+      "region": "sa-east-1",
+      "service": "ROUTE53_HEALTHCHECKS"
+    },
+    {
+      "ip_prefix": "54.252.79.128/26",
+      "region": "ap-southeast-2",
+      "service": "ROUTE53_HEALTHCHECKS"
+    },
+    {
+      "ip_prefix": "52.95.154.0/23",
+      "region": "eu-west-3",
+      "service": "S3"
+    },
+    {
+      "ip_prefix": "52.219.64.0/22",
+      "region": "ap-south-1",
+      "service": "S3"
+    },
+    {
+      "ip_prefix": "52.92.72.0/22",
+      "region": "sa-east-1",
+      "service": "S3"
+    },
+    {
+      "ip_prefix": "3.5.16.0/21",
+      "region": "us-east-1",
+      "service": "S3"
+    },
+    {
+      "ip_prefix": "52.92.64.0/22",
+      "region": "sa-east-1",
+      "service": "S3"
+    },
+    {
+      "ip_prefix": "52.95.156.0/24",
+      "region": "eu-west-3",
+      "service": "S3"
+    },
+    {
+      "ip_prefix": "3.5.208.0/22",
+      "region": "ap-south-1",
+      "service": "S3"
+    },
+    {
+      "ip_prefix": "52.95.150.0/24",
+      "region": "eu-west-2",
+      "service": "S3"
+    },
+    {
+      "ip_prefix": "52.219.60.0/23",
+      "region": "ap-northeast-2",
+      "service": "S3"
+    },
+    {
+      "ip_prefix": "52.92.48.0/22",
+      "region": "us-west-1",
+      "service": "S3"
+    },
+    {
+      "ip_prefix": "52.92.0.0/20",
+      "region": "ap-northeast-2",
+      "service": "S3"
+    },
+    {
+      "ip_prefix": "52.219.132.0/22",
+      "region": "ap-southeast-1",
+      "service": "S3"
+    },
+    {
+      "ip_prefix": "52.95.170.0/23",
+      "region": "eu-north-1",
+      "service": "S3"
+    },
+    {
+      "ip_prefix": "52.92.56.0/22",
+      "region": "ap-southeast-1",
+      "service": "S3"
+    },
+    {
+      "ip_prefix": "52.95.142.0/23",
+      "region": "us-gov-west-1",
+      "service": "S3"
+    },
+    {
+      "ip_prefix": "54.231.232.0/21",
+      "region": "us-west-1",
+      "service": "S3"
+    },
+    {
+      "ip_prefix": "54.222.52.0/22",
+      "region": "cn-north-1",
+      "service": "S3"
+    },
+    {
+      "ip_prefix": "54.231.128.0/19",
+      "region": "eu-west-1",
+      "service": "S3"
+    },
+    {
+      "ip_prefix": "52.218.128.0/17",
+      "region": "us-west-2",
+      "service": "S3"
+    },
+    {
+      "ip_prefix": "52.95.157.0/24",
+      "region": "ap-northeast-3",
+      "service": "S3"
+    },
+    {
+      "ip_prefix": "108.175.52.0/22",
+      "region": "us-gov-east-1",
+      "service": "S3"
+    },
+    {
+      "ip_prefix": "52.82.164.0/22",
+      "region": "cn-northwest-1",
+      "service": "S3"
+    },
+    {
+      "ip_prefix": "54.231.0.0/17",
+      "region": "us-east-1",
+      "service": "S3"
+    },
+    {
+      "ip_prefix": "52.219.20.0/22",
+      "region": "us-west-1",
+      "service": "S3"
+    },
+    {
+      "ip_prefix": "52.219.24.0/21",
+      "region": "us-west-1",
+      "service": "S3"
+    },
+    {
+      "ip_prefix": "52.219.96.0/20",
+      "region": "us-east-2",
+      "service": "S3"
+    },
+    {
+      "ip_prefix": "52.219.72.0/22",
+      "region": "eu-central-1",
+      "service": "S3"
+    },
+    {
+      "ip_prefix": "52.219.120.0/22",
+      "region": "us-west-1",
+      "service": "S3"
+    },
+    {
+      "ip_prefix": "54.222.48.0/22",
+      "region": "cn-north-1",
+      "service": "S3"
+    },
+    {
+      "ip_prefix": "52.219.56.0/22",
+      "region": "ap-northeast-2",
+      "service": "S3"
+    },
+    {
+      "ip_prefix": "52.95.174.0/24",
+      "region": "me-south-1",
+      "service": "S3"
+    },
+    {
+      "ip_prefix": "108.175.48.0/22",
+      "region": "us-gov-west-1",
+      "service": "S3"
+    },
+    {
+      "ip_prefix": "54.231.248.0/22",
+      "region": "ap-southeast-2",
+      "service": "S3"
+    },
+    {
+      "ip_prefix": "52.218.0.0/17",
+      "region": "eu-west-1",
+      "service": "S3"
+    },
+    {
+      "ip_prefix": "52.219.44.0/22",
+      "region": "eu-central-1",
+      "service": "S3"
+    },
+    {
+      "ip_prefix": "52.95.144.0/24",
+      "region": "us-gov-west-1",
+      "service": "S3"
+    },
+    {
+      "ip_prefix": "52.95.176.0/24",
+      "region": "af-south-1",
+      "service": "S3"
+    },
+    {
+      "ip_prefix": "3.5.132.0/23",
+      "region": "us-east-2",
+      "service": "S3"
+    },
+    {
+      "ip_prefix": "52.92.16.0/20",
+      "region": "us-east-1",
+      "service": "S3"
+    },
+    {
+      "ip_prefix": "54.231.252.0/24",
+      "region": "ap-southeast-2",
+      "service": "S3"
+    },
+    {
+      "ip_prefix": "52.219.0.0/20",
+      "region": "ap-northeast-1",
+      "service": "S3"
+    },
+    {
+      "ip_prefix": "52.219.40.0/22",
+      "region": "ap-southeast-1",
+      "service": "S3"
+    },
+    {
+      "ip_prefix": "52.219.136.0/22",
+      "region": "ap-northeast-1",
+      "service": "S3"
+    },
+    {
+      "ip_prefix": "52.95.163.0/24",
+      "region": "sa-east-1",
+      "service": "S3"
+    },
+    {
+      "ip_prefix": "52.95.145.0/24",
+      "region": "ca-central-1",
+      "service": "S3"
+    },
+    {
+      "ip_prefix": "52.92.40.0/21",
+      "region": "eu-west-1",
+      "service": "S3"
+    },
+    {
+      "ip_prefix": "52.219.32.0/21",
+      "region": "ap-southeast-1",
+      "service": "S3"
+    },
+    {
+      "ip_prefix": "52.95.136.0/23",
+      "region": "sa-east-1",
+      "service": "S3"
+    },
+    {
+      "ip_prefix": "52.219.48.0/22",
+      "region": "ap-southeast-1",
+      "service": "S3"
+    },
+    {
+      "ip_prefix": "52.219.62.0/23",
+      "region": "ap-south-1",
+      "service": "S3"
+    },
+    {
+      "ip_prefix": "52.95.175.0/24",
+      "region": "af-south-1",
+      "service": "S3"
+    },
+    {
+      "ip_prefix": "52.219.80.0/20",
+      "region": "us-east-2",
+      "service": "S3"
+    },
+    {
+      "ip_prefix": "52.95.148.0/23",
+      "region": "eu-west-2",
+      "service": "S3"
+    },
+    {
+      "ip_prefix": "52.92.88.0/22",
+      "region": "eu-west-2",
+      "service": "S3"
+    },
+    {
+      "ip_prefix": "3.5.0.0/20",
+      "region": "us-east-1",
+      "service": "S3"
+    },
+    {
+      "ip_prefix": "52.95.169.0/24",
+      "region": "eu-north-1",
+      "service": "S3"
+    },
+    {
+      "ip_prefix": "52.95.164.0/23",
+      "region": "sa-east-1",
+      "service": "S3"
+    },
+    {
+      "ip_prefix": "52.92.32.0/22",
+      "region": "us-west-2",
+      "service": "S3"
+    },
+    {
+      "ip_prefix": "52.95.172.0/23",
+      "region": "me-south-1",
+      "service": "S3"
+    },
+    {
+      "ip_prefix": "52.92.68.0/22",
+      "region": "eu-central-1",
+      "service": "S3"
+    },
+    {
+      "ip_prefix": "52.219.112.0/21",
+      "region": "us-west-1",
+      "service": "S3"
+    },
+    {
+      "ip_prefix": "52.219.16.0/22",
+      "region": "ap-northeast-1",
+      "service": "S3"
+    },
+    {
+      "ip_prefix": "52.219.124.0/22",
+      "region": "ap-southeast-1",
+      "service": "S3"
+    },
+    {
+      "ip_prefix": "3.5.128.0/22",
+      "region": "us-east-2",
+      "service": "S3"
+    },
+    {
+      "ip_prefix": "54.231.160.0/19",
+      "region": "us-west-2",
+      "service": "S3"
+    },
+    {
+      "ip_prefix": "52.92.76.0/22",
+      "region": "us-east-2",
+      "service": "S3"
+    },
+    {
+      "ip_prefix": "52.92.52.0/22",
+      "region": "ap-southeast-2",
+      "service": "S3"
+    },
+    {
+      "ip_prefix": "52.92.60.0/22",
+      "region": "ap-northeast-1",
+      "service": "S3"
+    },
+    {
+      "ip_prefix": "52.219.68.0/22",
+      "region": "ap-northeast-1",
+      "service": "S3"
+    },
+    {
+      "ip_prefix": "52.219.128.0/22",
+      "region": "ap-southeast-1",
+      "service": "S3"
+    },
+    {
+      "ip_prefix": "52.95.146.0/23",
+      "region": "ca-central-1",
+      "service": "S3"
+    },
+    {
+      "ip_prefix": "52.95.162.0/24",
+      "region": "ap-east-1",
+      "service": "S3"
+    },
+    {
+      "ip_prefix": "52.92.248.0/22",
+      "region": "ap-south-1",
+      "service": "S3"
+    },
+    {
+      "ip_prefix": "52.95.128.0/21",
+      "region": "ap-southeast-2",
+      "service": "S3"
+    },
+    {
+      "ip_prefix": "3.5.212.0/23",
+      "region": "ap-south-1",
+      "service": "S3"
+    },
+    {
+      "ip_prefix": "52.95.138.0/24",
+      "region": "sa-east-1",
+      "service": "S3"
+    },
+    {
+      "ip_prefix": "52.95.160.0/23",
+      "region": "ap-east-1",
+      "service": "S3"
+    },
+    {
+      "ip_prefix": "52.95.158.0/23",
+      "region": "ap-northeast-3",
+      "service": "S3"
+    },
+    {
+      "ip_prefix": "52.216.0.0/15",
+      "region": "us-east-1",
+      "service": "S3"
+    },
+    {
+      "ip_prefix": "52.82.188.0/22",
+      "region": "cn-northwest-1",
+      "service": "S3"
+    },
+    {
+      "ip_prefix": "52.95.166.0/23",
+      "region": "us-gov-east-1",
+      "service": "S3"
+    },
+    {
+      "ip_prefix": "52.95.168.0/24",
+      "region": "us-gov-east-1",
+      "service": "S3"
+    },
+    {
+      "ip_prefix": "52.92.252.0/22",
+      "region": "us-gov-west-1",
+      "service": "S3"
+    },
+    {
+      "ip_prefix": "54.231.192.0/20",
+      "region": "eu-central-1",
+      "service": "S3"
+    },
+    {
+      "ip_prefix": "52.94.22.0/24",
+      "region": "us-gov-east-1",
+      "service": "DYNAMODB"
+    },
+    {
+      "ip_prefix": "52.94.17.0/24",
+      "region": "eu-central-1",
+      "service": "DYNAMODB"
+    },
+    {
+      "ip_prefix": "52.119.224.0/21",
+      "region": "us-east-1",
+      "service": "DYNAMODB"
+    },
+    {
+      "ip_prefix": "52.119.249.0/24",
+      "region": "me-south-1",
+      "service": "DYNAMODB"
+    },
+    {
+      "ip_prefix": "52.94.8.0/24",
+      "region": "ap-northeast-1",
+      "service": "DYNAMODB"
+    },
+    {
+      "ip_prefix": "52.94.20.0/24",
+      "region": "ap-south-1",
+      "service": "DYNAMODB"
+    },
+    {
+      "ip_prefix": "52.82.187.0/24",
+      "region": "cn-northwest-1",
+      "service": "DYNAMODB"
+    },
+    {
+      "ip_prefix": "52.94.19.0/24",
+      "region": "ap-northeast-3",
+      "service": "DYNAMODB"
+    },
+    {
+      "ip_prefix": "52.119.232.0/21",
+      "region": "us-east-1",
+      "service": "DYNAMODB"
+    },
+    {
+      "ip_prefix": "52.94.13.0/24",
+      "region": "ap-southeast-2",
+      "service": "DYNAMODB"
+    },
+    {
+      "ip_prefix": "52.94.5.0/24",
+      "region": "eu-west-1",
+      "service": "DYNAMODB"
+    },
+    {
+      "ip_prefix": "52.94.23.0/24",
+      "region": "eu-north-1",
+      "service": "DYNAMODB"
+    },
+    {
+      "ip_prefix": "52.94.4.0/24",
+      "region": "us-east-2",
+      "service": "DYNAMODB"
+    },
+    {
+      "ip_prefix": "52.94.16.0/24",
+      "region": "eu-west-3",
+      "service": "DYNAMODB"
+    },
+    {
+      "ip_prefix": "52.119.248.0/24",
+      "region": "ap-east-1",
+      "service": "DYNAMODB"
+    },
+    {
+      "ip_prefix": "52.94.15.0/24",
+      "region": "eu-west-2",
+      "service": "DYNAMODB"
+    },
+    {
+      "ip_prefix": "52.94.26.0/23",
+      "region": "eu-west-1",
+      "service": "DYNAMODB"
+    },
+    {
+      "ip_prefix": "52.94.30.0/24",
+      "region": "af-south-1",
+      "service": "DYNAMODB"
+    },
+    {
+      "ip_prefix": "52.119.240.0/21",
+      "region": "eu-west-1",
+      "service": "DYNAMODB"
+    },
+    {
+      "ip_prefix": "52.94.9.0/24",
+      "region": "us-gov-west-1",
+      "service": "DYNAMODB"
+    },
+    {
+      "ip_prefix": "52.94.28.0/23",
+      "region": "us-west-2",
+      "service": "DYNAMODB"
+    },
+    {
+      "ip_prefix": "52.94.11.0/24",
+      "region": "ap-southeast-1",
+      "service": "DYNAMODB"
+    },
+    {
+      "ip_prefix": "52.94.24.0/23",
+      "region": "eu-west-1",
+      "service": "DYNAMODB"
+    },
+    {
+      "ip_prefix": "52.94.12.0/24",
+      "region": "us-west-1",
+      "service": "DYNAMODB"
+    },
+    {
+      "ip_prefix": "52.94.6.0/24",
+      "region": "ap-northeast-2",
+      "service": "DYNAMODB"
+    },
+    {
+      "ip_prefix": "52.119.252.0/22",
+      "region": "us-west-2",
+      "service": "DYNAMODB"
+    },
+    {
+      "ip_prefix": "52.94.0.0/22",
+      "region": "us-east-1",
+      "service": "DYNAMODB"
+    },
+    {
+      "ip_prefix": "54.222.57.0/24",
+      "region": "cn-north-1",
+      "service": "DYNAMODB"
+    },
+    {
+      "ip_prefix": "52.94.14.0/24",
+      "region": "ca-central-1",
+      "service": "DYNAMODB"
+    },
+    {
+      "ip_prefix": "52.94.10.0/24",
+      "region": "us-west-2",
+      "service": "DYNAMODB"
+    },
+    {
+      "ip_prefix": "52.94.7.0/24",
+      "region": "sa-east-1",
+      "service": "DYNAMODB"
+    },
+    {
+      "ip_prefix": "18.208.0.0/13",
+      "region": "us-east-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "52.95.245.0/24",
+      "region": "us-east-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "54.240.17.0/24",
+      "region": "ap-east-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "99.77.142.0/24",
+      "region": "ap-east-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "52.194.0.0/15",
+      "region": "ap-northeast-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "54.155.0.0/16",
+      "region": "eu-west-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "54.196.0.0/15",
+      "region": "us-east-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "52.95.255.112/28",
+      "region": "us-west-2",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "13.210.0.0/15",
+      "region": "ap-southeast-2",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "54.241.0.0/16",
+      "region": "us-west-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "184.169.128.0/17",
+      "region": "us-west-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "216.182.224.0/21",
+      "region": "us-east-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "15.193.2.0/24",
+      "region": "ap-southeast-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "99.77.132.0/24",
+      "region": "us-west-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "52.74.0.0/16",
+      "region": "ap-southeast-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "54.168.0.0/16",
+      "region": "ap-northeast-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "54.238.0.0/16",
+      "region": "ap-northeast-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "216.182.232.0/22",
+      "region": "us-east-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "3.5.16.0/21",
+      "region": "us-east-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "13.125.0.0/16",
+      "region": "ap-northeast-2",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "54.193.0.0/16",
+      "region": "us-west-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "54.222.59.0/24",
+      "region": "cn-north-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "99.77.247.0/24",
+      "region": "eu-central-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "54.250.0.0/16",
+      "region": "ap-northeast-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "107.20.0.0/14",
+      "region": "us-east-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "99.77.128.0/24",
+      "region": "us-east-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "15.177.77.0/24",
+      "region": "ap-northeast-3",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "54.180.0.0/15",
+      "region": "ap-northeast-2",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "99.77.253.0/24",
+      "region": "us-west-2",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "3.5.208.0/22",
+      "region": "ap-south-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "15.177.76.0/24",
+      "region": "ap-northeast-2",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "52.30.0.0/15",
+      "region": "eu-west-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "52.94.249.64/28",
+      "region": "us-west-2",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "54.92.0.0/17",
+      "region": "ap-northeast-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "54.154.0.0/16",
+      "region": "eu-west-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "67.202.0.0/18",
+      "region": "us-east-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "52.94.248.112/28",
+      "region": "eu-central-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "54.232.0.0/16",
+      "region": "sa-east-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "52.94.116.0/22",
+      "region": "us-west-2",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "208.86.90.0/23",
+      "region": "eu-west-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "3.136.0.0/13",
+      "region": "us-east-2",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "52.94.248.192/28",
+      "region": "eu-west-2",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "184.73.0.0/16",
+      "region": "us-east-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "18.183.0.0/16",
+      "region": "ap-northeast-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "46.137.0.0/17",
+      "region": "eu-west-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "99.77.135.0/24",
+      "region": "eu-west-3",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "3.80.0.0/12",
+      "region": "us-east-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "3.101.0.0/16",
+      "region": "us-west-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "52.40.0.0/14",
+      "region": "us-west-2",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "15.193.4.0/24",
+      "region": "eu-central-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "35.181.0.0/16",
+      "region": "eu-west-3",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "54.80.0.0/13",
+      "region": "us-east-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "54.214.0.0/16",
+      "region": "us-west-2",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "54.254.0.0/16",
+      "region": "ap-southeast-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "52.95.254.0/24",
+      "region": "eu-west-3",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "176.32.64.0/19",
+      "region": "ap-northeast-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "3.224.0.0/12",
+      "region": "us-east-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "54.221.0.0/16",
+      "region": "us-east-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "54.255.0.0/16",
+      "region": "ap-southeast-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "18.253.0.0/16",
+      "region": "us-gov-east-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "52.94.249.112/28",
+      "region": "us-gov-east-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "13.208.0.0/16",
+      "region": "ap-northeast-3",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "15.193.7.0/24",
+      "region": "us-west-2",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "54.156.0.0/14",
+      "region": "us-east-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "54.236.0.0/15",
+      "region": "us-east-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "52.95.249.0/24",
+      "region": "ap-south-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "54.244.0.0/16",
+      "region": "us-west-2",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "52.95.255.128/28",
+      "region": "eu-central-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "52.208.0.0/13",
+      "region": "eu-west-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "13.228.0.0/15",
+      "region": "ap-southeast-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "52.94.248.96/28",
+      "region": "us-west-2",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "52.196.0.0/14",
+      "region": "ap-northeast-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "99.77.150.0/24",
+      "region": "ca-central-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "52.32.0.0/14",
+      "region": "us-west-2",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "52.95.252.0/24",
+      "region": "ap-northeast-2",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "54.222.36.0/22",
+      "region": "cn-north-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "52.18.0.0/15",
+      "region": "eu-west-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "175.41.192.0/18",
+      "region": "ap-northeast-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "52.94.248.160/28",
+      "region": "us-east-2",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "54.151.0.0/17",
+      "region": "us-west-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "13.54.0.0/15",
+      "region": "ap-southeast-2",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "52.95.241.0/24",
+      "region": "ap-southeast-2",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "99.77.144.0/24",
+      "region": "ap-southeast-2",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "54.222.52.0/22",
+      "region": "cn-north-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "99.80.0.0/15",
+      "region": "eu-west-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "3.34.0.0/15",
+      "region": "ap-northeast-2",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "15.177.74.0/24",
+      "region": "eu-west-3",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "52.65.0.0/16",
+      "region": "ap-southeast-2",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "54.150.0.0/16",
+      "region": "ap-northeast-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "18.200.0.0/16",
+      "region": "eu-west-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "54.206.0.0/16",
+      "region": "ap-southeast-2",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "52.95.255.96/28",
+      "region": "us-west-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "54.226.0.0/15",
+      "region": "us-east-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "162.250.237.0/24",
+      "region": "us-east-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "15.177.86.0/24",
+      "region": "ap-east-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "18.144.0.0/15",
+      "region": "us-west-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "52.90.0.0/15",
+      "region": "us-east-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "52.10.0.0/15",
+      "region": "us-west-2",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "52.82.164.0/22",
+      "region": "cn-northwest-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "100.24.0.0/13",
+      "region": "us-east-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "54.74.0.0/15",
+      "region": "eu-west-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "3.104.0.0/14",
+      "region": "ap-southeast-2",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "15.193.5.0/24",
+      "region": "eu-west-2",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "52.80.0.0/16",
+      "region": "cn-north-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "175.41.128.0/18",
+      "region": "ap-southeast-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "54.216.0.0/15",
+      "region": "eu-west-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "54.78.0.0/16",
+      "region": "eu-west-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "99.77.139.0/24",
+      "region": "ap-northeast-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "18.190.0.0/16",
+      "region": "us-east-2",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "52.82.168.0/24",
+      "region": "cn-northwest-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "162.213.232.0/24",
+      "region": "eu-west-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "15.188.0.0/16",
+      "region": "eu-west-3",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "54.200.0.0/15",
+      "region": "us-west-2",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "35.160.0.0/13",
+      "region": "us-west-2",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "52.48.0.0/14",
+      "region": "eu-west-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "99.77.137.0/24",
+      "region": "eu-north-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "204.236.128.0/18",
+      "region": "us-west-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "162.213.233.0/24",
+      "region": "eu-west-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "13.48.0.0/15",
+      "region": "eu-north-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "52.64.0.0/17",
+      "region": "ap-southeast-2",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "52.95.239.0/24",
+      "region": "eu-west-2",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "15.177.91.0/24",
+      "region": "af-south-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "35.155.0.0/16",
+      "region": "us-west-2",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "54.210.0.0/15",
+      "region": "us-east-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "18.163.0.0/16",
+      "region": "ap-east-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "54.199.0.0/16",
+      "region": "ap-northeast-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "54.198.0.0/16",
+      "region": "us-east-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "52.20.0.0/14",
+      "region": "us-east-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "52.94.201.0/26",
+      "region": "us-east-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "52.94.248.208/28",
+      "region": "ca-central-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "18.142.0.0/15",
+      "region": "ap-southeast-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "46.137.192.0/19",
+      "region": "ap-southeast-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "52.200.0.0/13",
+      "region": "us-east-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "54.222.32.0/22",
+      "region": "cn-north-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "52.76.0.0/17",
+      "region": "ap-southeast-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "15.177.82.0/24",
+      "region": "ap-southeast-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "54.153.128.0/17",
+      "region": "ap-southeast-2",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "122.248.192.0/18",
+      "region": "ap-southeast-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "54.207.0.0/16",
+      "region": "sa-east-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "99.77.145.0/24",
+      "region": "ap-south-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "15.200.0.0/16",
+      "region": "us-gov-west-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "35.154.0.0/16",
+      "region": "ap-south-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "52.82.0.0/17",
+      "region": "cn-northwest-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "52.94.249.32/28",
+      "region": "eu-west-3",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "54.170.0.0/15",
+      "region": "eu-west-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "15.177.87.0/24",
+      "region": "me-south-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "54.160.0.0/13",
+      "region": "us-east-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "157.175.0.0/16",
+      "region": "me-south-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "176.34.32.0/19",
+      "region": "ap-northeast-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "18.236.0.0/15",
+      "region": "us-west-2",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "52.94.249.80/28",
+      "region": "us-west-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "46.51.192.0/20",
+      "region": "eu-west-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "99.77.149.0/24",
+      "region": "sa-east-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "162.250.238.0/23",
+      "region": "us-east-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "35.176.0.0/15",
+      "region": "eu-west-2",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "70.224.192.0/18",
+      "region": "us-west-2",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "3.24.0.0/14",
+      "region": "ap-southeast-2",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "35.153.0.0/16",
+      "region": "us-east-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "52.61.0.0/16",
+      "region": "us-gov-west-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "52.79.0.0/16",
+      "region": "ap-northeast-2",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "18.230.0.0/16",
+      "region": "sa-east-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "52.58.0.0/15",
+      "region": "eu-central-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "52.62.0.0/15",
+      "region": "ap-southeast-2",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "15.222.0.0/15",
+      "region": "ca-central-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "15.177.73.0/24",
+      "region": "ap-south-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "46.51.216.0/21",
+      "region": "ap-southeast-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "52.28.0.0/16",
+      "region": "eu-central-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "52.57.0.0/16",
+      "region": "eu-central-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "18.132.0.0/14",
+      "region": "eu-west-2",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "52.70.0.0/15",
+      "region": "us-east-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "52.94.248.0/28",
+      "region": "us-east-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "52.29.0.0/16",
+      "region": "eu-central-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "15.177.70.0/23",
+      "region": "sa-east-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "15.236.0.0/15",
+      "region": "eu-west-3",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "99.77.254.0/24",
+      "region": "us-east-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "184.72.0.0/18",
+      "region": "us-west-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "52.95.246.0/24",
+      "region": "us-west-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "15.177.83.0/24",
+      "region": "ap-southeast-2",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "15.185.0.0/16",
+      "region": "me-south-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "54.247.0.0/16",
+      "region": "eu-west-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "54.248.0.0/15",
+      "region": "ap-northeast-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "52.46.180.0/22",
+      "region": "us-west-2",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "52.95.227.0/24",
+      "region": "eu-north-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "54.68.0.0/14",
+      "region": "us-west-2",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "54.93.0.0/16",
+      "region": "eu-central-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "52.54.0.0/15",
+      "region": "us-east-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "52.95.230.0/24",
+      "region": "us-west-2",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "18.182.0.0/16",
+      "region": "ap-northeast-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "54.152.0.0/16",
+      "region": "us-east-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "13.112.0.0/14",
+      "region": "ap-northeast-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "52.68.0.0/15",
+      "region": "ap-northeast-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "54.67.0.0/16",
+      "region": "us-west-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "15.177.0.0/18",
+      "region": "GLOBAL",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "18.194.0.0/15",
+      "region": "eu-central-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "52.94.249.128/28",
+      "region": "eu-north-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "54.184.0.0/13",
+      "region": "us-west-2",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "3.13.0.0/16",
+      "region": "us-east-2",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "3.248.0.0/13",
+      "region": "eu-west-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "54.92.128.0/17",
+      "region": "us-east-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "99.77.133.0/24",
+      "region": "eu-west-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "52.0.0.0/15",
+      "region": "us-east-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "52.82.184.0/23",
+      "region": "cn-northwest-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "52.95.253.0/24",
+      "region": "eu-west-2",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "140.179.0.0/16",
+      "region": "cn-north-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "3.5.132.0/23",
+      "region": "us-east-2",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "13.53.0.0/16",
+      "region": "eu-north-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "15.177.88.0/24",
+      "region": "sa-east-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "184.72.128.0/17",
+      "region": "us-east-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "13.58.0.0/15",
+      "region": "us-east-2",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "54.194.0.0/15",
+      "region": "eu-west-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "35.156.0.0/14",
+      "region": "eu-central-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "23.20.0.0/14",
+      "region": "us-east-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "52.94.248.80/28",
+      "region": "ap-northeast-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "64.252.64.0/24",
+      "region": "us-east-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "99.77.143.0/24",
+      "region": "ap-southeast-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "52.95.225.0/24",
+      "region": "ap-northeast-3",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "18.229.0.0/16",
+      "region": "sa-east-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "54.219.0.0/16",
+      "region": "us-west-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "18.204.0.0/14",
+      "region": "us-east-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "35.178.0.0/15",
+      "region": "eu-west-2",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "54.88.0.0/14",
+      "region": "us-east-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "52.12.0.0/15",
+      "region": "us-west-2",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "52.220.0.0/15",
+      "region": "ap-southeast-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "162.250.236.0/24",
+      "region": "us-east-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "34.240.0.0/13",
+      "region": "eu-west-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "52.94.248.16/28",
+      "region": "eu-west-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "52.94.249.96/28",
+      "region": "ap-northeast-3",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "54.253.0.0/16",
+      "region": "ap-southeast-2",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "18.166.0.0/15",
+      "region": "ap-east-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "52.94.248.128/28",
+      "region": "us-west-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "99.77.250.0/24",
+      "region": "eu-west-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "52.94.248.64/28",
+      "region": "ap-southeast-2",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "52.95.229.0/24",
+      "region": "af-south-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "54.72.0.0/15",
+      "region": "eu-west-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "54.223.0.0/16",
+      "region": "cn-north-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "99.77.129.0/24",
+      "region": "us-east-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "15.177.89.0/24",
+      "region": "eu-west-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "18.156.0.0/14",
+      "region": "eu-central-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "79.125.0.0/17",
+      "region": "eu-west-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "99.77.134.0/24",
+      "region": "eu-west-2",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "52.88.0.0/15",
+      "region": "us-west-2",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "3.131.0.0/16",
+      "region": "us-east-2",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "52.94.248.32/28",
+      "region": "ap-southeast-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "54.220.0.0/16",
+      "region": "eu-west-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "100.20.0.0/14",
+      "region": "us-west-2",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "3.8.0.0/14",
+      "region": "eu-west-2",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "18.246.0.0/16",
+      "region": "us-west-2",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "54.204.0.0/15",
+      "region": "us-east-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "216.182.236.0/23",
+      "region": "us-west-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "34.208.0.0/12",
+      "region": "us-west-2",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "52.15.0.0/16",
+      "region": "us-east-2",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "18.162.0.0/16",
+      "region": "ap-east-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "15.177.64.0/23",
+      "region": "us-east-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "52.86.0.0/15",
+      "region": "us-east-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "52.44.0.0/15",
+      "region": "us-east-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "52.76.128.0/17",
+      "region": "ap-southeast-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "54.95.0.0/16",
+      "region": "ap-northeast-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "54.212.0.0/15",
+      "region": "us-west-2",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "18.232.0.0/14",
+      "region": "us-east-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "52.82.169.0/28",
+      "region": "cn-northwest-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "52.47.0.0/16",
+      "region": "eu-west-3",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "52.94.249.144/28",
+      "region": "ap-east-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "52.95.255.64/28",
+      "region": "eu-west-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "99.77.147.0/24",
+      "region": "me-south-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "162.213.234.0/23",
+      "region": "eu-west-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "3.132.0.0/14",
+      "region": "us-east-2",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "63.32.0.0/14",
+      "region": "eu-west-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "52.83.0.0/16",
+      "region": "cn-northwest-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "54.79.0.0/16",
+      "region": "ap-southeast-2",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "54.251.0.0/16",
+      "region": "ap-southeast-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "18.189.0.0/16",
+      "region": "us-east-2",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "18.153.0.0/16",
+      "region": "eu-central-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "18.202.0.0/15",
+      "region": "eu-west-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "3.20.0.0/14",
+      "region": "us-east-2",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "18.196.0.0/15",
+      "region": "eu-central-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "54.76.0.0/15",
+      "region": "eu-west-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "52.95.255.16/28",
+      "region": "ap-southeast-2",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "13.232.0.0/14",
+      "region": "ap-south-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "52.95.243.0/24",
+      "region": "ap-northeast-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "15.177.80.0/24",
+      "region": "us-west-2",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "54.174.0.0/15",
+      "region": "us-east-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "50.16.0.0/15",
+      "region": "us-east-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "52.52.0.0/15",
+      "region": "us-west-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "54.233.64.0/18",
+      "region": "sa-east-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "35.168.0.0/13",
+      "region": "us-east-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "52.64.128.0/17",
+      "region": "ap-southeast-2",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "52.95.228.0/24",
+      "region": "me-south-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "54.222.128.0/17",
+      "region": "cn-north-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "96.127.0.0/17",
+      "region": "us-gov-west-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "54.148.0.0/15",
+      "region": "us-west-2",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "99.77.130.0/24",
+      "region": "us-west-2",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "35.182.0.0/15",
+      "region": "ca-central-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "99.77.191.0/24",
+      "region": "us-east-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "3.112.0.0/14",
+      "region": "ap-northeast-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "52.95.244.0/24",
+      "region": "eu-west-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "3.208.0.0/12",
+      "region": "us-east-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "54.222.64.0/23",
+      "region": "cn-north-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "185.48.120.0/22",
+      "region": "eu-west-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "3.5.0.0/20",
+      "region": "us-east-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "18.220.0.0/14",
+      "region": "us-east-2",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "52.36.0.0/14",
+      "region": "us-west-2",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "54.94.0.0/16",
+      "region": "sa-east-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "18.191.0.0/16",
+      "region": "us-east-2",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "18.178.0.0/16",
+      "region": "ap-northeast-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "54.202.0.0/15",
+      "region": "us-west-2",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "3.128.0.0/15",
+      "region": "us-east-2",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "34.248.0.0/13",
+      "region": "eu-west-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "15.206.0.0/15",
+      "region": "ap-south-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "50.18.0.0/16",
+      "region": "us-west-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "52.14.0.0/16",
+      "region": "us-east-2",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "3.12.0.0/16",
+      "region": "us-east-2",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "13.124.0.0/16",
+      "region": "ap-northeast-2",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "52.94.248.144/28",
+      "region": "ap-south-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "52.192.0.0/15",
+      "region": "ap-northeast-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "52.95.255.32/28",
+      "region": "ap-southeast-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "160.1.0.0/16",
+      "region": "us-gov-west-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "13.236.0.0/14",
+      "region": "ap-southeast-2",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "52.95.226.0/24",
+      "region": "ap-east-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "174.129.0.0/16",
+      "region": "us-east-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "13.209.0.0/16",
+      "region": "ap-northeast-2",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "18.140.0.0/15",
+      "region": "ap-southeast-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "52.60.0.0/16",
+      "region": "ca-central-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "52.78.0.0/16",
+      "region": "ap-northeast-2",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "72.44.32.0/19",
+      "region": "us-east-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "34.224.0.0/12",
+      "region": "us-east-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "52.75.0.0/16",
+      "region": "us-west-2",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "13.230.0.0/15",
+      "region": "ap-northeast-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "52.94.249.160/28",
+      "region": "me-south-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "54.224.0.0/15",
+      "region": "us-east-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "15.164.0.0/15",
+      "region": "ap-northeast-2",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "176.34.128.0/17",
+      "region": "eu-west-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "52.95.240.0/24",
+      "region": "sa-east-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "75.101.128.0/17",
+      "region": "us-east-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "54.178.0.0/16",
+      "region": "ap-northeast-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "108.128.0.0/13",
+      "region": "eu-west-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "13.56.0.0/16",
+      "region": "us-west-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "18.184.0.0/15",
+      "region": "eu-central-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "3.5.128.0/22",
+      "region": "us-east-2",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "18.216.0.0/14",
+      "region": "us-east-2",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "34.192.0.0/12",
+      "region": "us-east-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "54.215.0.0/16",
+      "region": "us-west-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "15.177.68.0/23",
+      "region": "eu-central-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "177.71.128.0/17",
+      "region": "sa-east-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "18.175.0.0/16",
+      "region": "eu-west-2",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "54.208.0.0/15",
+      "region": "us-east-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "54.228.0.0/16",
+      "region": "eu-west-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "18.192.0.0/15",
+      "region": "eu-central-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "54.229.0.0/16",
+      "region": "eu-west-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "18.138.0.0/15",
+      "region": "ap-southeast-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "52.95.255.144/28",
+      "region": "cn-north-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "3.120.0.0/14",
+      "region": "eu-central-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "18.198.0.0/15",
+      "region": "eu-central-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "52.9.0.0/16",
+      "region": "us-west-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "99.77.141.0/24",
+      "region": "ap-northeast-2",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "13.244.0.0/15",
+      "region": "af-south-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "52.94.248.48/28",
+      "region": "sa-east-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "54.242.0.0/15",
+      "region": "us-east-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "216.182.238.0/23",
+      "region": "us-east-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "35.180.0.0/16",
+      "region": "eu-west-3",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "3.14.0.0/15",
+      "region": "us-east-2",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "15.177.81.0/24",
+      "region": "us-west-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "18.228.0.0/16",
+      "region": "sa-east-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "52.16.0.0/15",
+      "region": "eu-west-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "52.95.242.0/24",
+      "region": "ap-southeast-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "161.189.0.0/16",
+      "region": "cn-northwest-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "13.52.0.0/16",
+      "region": "us-west-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "18.180.0.0/15",
+      "region": "ap-northeast-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "46.137.128.0/18",
+      "region": "eu-west-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "52.94.248.176/28",
+      "region": "ap-northeast-2",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "54.234.0.0/15",
+      "region": "us-east-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "18.188.0.0/16",
+      "region": "us-east-2",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "18.252.0.0/16",
+      "region": "us-gov-east-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "46.51.128.0/18",
+      "region": "eu-west-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "15.177.84.0/24",
+      "region": "ca-central-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "52.94.249.176/28",
+      "region": "af-south-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "54.153.0.0/17",
+      "region": "us-west-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "15.177.75.0/24",
+      "region": "eu-west-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "52.24.0.0/14",
+      "region": "us-west-2",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "52.222.0.0/17",
+      "region": "us-gov-west-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "64.252.65.0/24",
+      "region": "us-west-2",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "15.177.66.0/23",
+      "region": "us-east-2",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "52.94.248.224/28",
+      "region": "us-gov-west-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "52.95.255.48/28",
+      "region": "ap-northeast-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "54.218.0.0/16",
+      "region": "us-west-2",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "3.124.0.0/14",
+      "region": "eu-central-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "52.82.176.0/22",
+      "region": "cn-northwest-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "54.183.0.0/16",
+      "region": "us-west-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "52.95.255.0/28",
+      "region": "sa-east-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "54.176.0.0/15",
+      "region": "us-west-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "54.246.0.0/16",
+      "region": "eu-west-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "18.231.0.0/16",
+      "region": "sa-east-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "54.252.0.0/16",
+      "region": "ap-southeast-2",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "46.137.224.0/19",
+      "region": "ap-southeast-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "54.144.0.0/14",
+      "region": "us-east-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "54.169.0.0/16",
+      "region": "ap-southeast-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "99.77.136.0/24",
+      "region": "eu-central-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "54.66.0.0/16",
+      "region": "ap-southeast-2",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "3.5.212.0/23",
+      "region": "ap-south-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "15.177.72.0/24",
+      "region": "eu-north-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "52.2.0.0/15",
+      "region": "us-east-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "103.4.8.0/21",
+      "region": "ap-northeast-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "184.72.64.0/18",
+      "region": "us-east-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "15.193.3.0/24",
+      "region": "ap-southeast-2",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "18.179.0.0/16",
+      "region": "ap-northeast-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "46.51.224.0/19",
+      "region": "ap-northeast-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "54.179.0.0/16",
+      "region": "ap-southeast-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "54.233.0.0/18",
+      "region": "sa-east-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "52.8.0.0/16",
+      "region": "us-west-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "52.95.247.0/24",
+      "region": "us-west-2",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "15.177.78.0/24",
+      "region": "eu-west-2",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "15.193.0.0/24",
+      "region": "ap-south-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "52.66.0.0/16",
+      "region": "ap-south-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "204.236.192.0/18",
+      "region": "us-east-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "15.177.79.0/24",
+      "region": "ap-northeast-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "54.64.0.0/15",
+      "region": "ap-northeast-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "176.34.0.0/19",
+      "region": "ap-northeast-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "52.95.248.0/24",
+      "region": "eu-central-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "54.222.58.32/28",
+      "region": "cn-north-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "15.193.6.0/24",
+      "region": "us-east-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "18.176.0.0/15",
+      "region": "ap-northeast-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "3.0.0.0/15",
+      "region": "ap-southeast-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "52.77.0.0/16",
+      "region": "ap-southeast-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "52.119.205.0/24",
+      "region": "ap-southeast-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "18.224.0.0/14",
+      "region": "us-east-2",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "52.56.0.0/16",
+      "region": "eu-west-2",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "54.245.0.0/16",
+      "region": "us-west-2",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "99.77.131.0/24",
+      "region": "us-east-2",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "15.177.85.0/24",
+      "region": "ap-east-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "52.95.251.0/24",
+      "region": "us-east-2",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "52.4.0.0/14",
+      "region": "us-east-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "3.6.0.0/15",
+      "region": "ap-south-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "15.193.1.0/24",
+      "region": "ap-northeast-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "52.46.184.0/22",
+      "region": "eu-central-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "52.67.0.0/16",
+      "region": "sa-east-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "18.201.0.0/16",
+      "region": "eu-west-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "54.151.128.0/17",
+      "region": "ap-southeast-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "208.86.88.0/23",
+      "region": "us-east-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "44.224.0.0/11",
+      "region": "us-west-2",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "52.81.0.0/16",
+      "region": "cn-north-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "13.250.0.0/15",
+      "region": "ap-southeast-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "44.192.0.0/11",
+      "region": "us-east-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "3.16.0.0/14",
+      "region": "us-east-2",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "18.130.0.0/16",
+      "region": "eu-west-2",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "52.72.0.0/15",
+      "region": "us-east-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "52.82.180.0/22",
+      "region": "cn-northwest-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "99.77.148.0/24",
+      "region": "af-south-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "18.136.0.0/16",
+      "region": "ap-southeast-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "50.112.0.0/16",
+      "region": "us-west-2",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "52.95.255.80/28",
+      "region": "us-east-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "52.95.250.0/24",
+      "region": "ca-central-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "50.19.0.0/16",
+      "region": "us-east-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "99.79.0.0/16",
+      "region": "ca-central-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "3.130.0.0/16",
+      "region": "us-east-2",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "13.57.0.0/16",
+      "region": "us-west-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "13.126.0.0/15",
+      "region": "ap-south-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "99.77.140.0/24",
+      "region": "ap-northeast-3",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "54.172.0.0/15",
+      "region": "us-east-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "176.34.64.0/18",
+      "region": "eu-west-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "54.233.128.0/17",
+      "region": "sa-east-1",
+      "service": "EC2"
+    },
+    {
+      "ip_prefix": "205.251.192.0/21",
+      "region": "GLOBAL",
+      "service": "ROUTE53"
+    },
+    {
+      "ip_prefix": "52.95.110.0/24",
+      "region": "GLOBAL",
+      "service": "ROUTE53"
+    },
+    {
+      "ip_prefix": "144.220.0.0/16",
+      "region": "GLOBAL",
+      "service": "CLOUDFRONT"
+    },
+    {
+      "ip_prefix": "52.124.128.0/17",
+      "region": "GLOBAL",
+      "service": "CLOUDFRONT"
+    },
+    {
+      "ip_prefix": "54.230.0.0/16",
+      "region": "GLOBAL",
+      "service": "CLOUDFRONT"
+    },
+    {
+      "ip_prefix": "54.239.128.0/18",
+      "region": "GLOBAL",
+      "service": "CLOUDFRONT"
+    },
+    {
+      "ip_prefix": "52.82.128.0/19",
+      "region": "GLOBAL",
+      "service": "CLOUDFRONT"
+    },
+    {
+      "ip_prefix": "99.84.0.0/16",
+      "region": "GLOBAL",
+      "service": "CLOUDFRONT"
+    },
+    {
+      "ip_prefix": "204.246.172.0/24",
+      "region": "GLOBAL",
+      "service": "CLOUDFRONT"
+    },
+    {
+      "ip_prefix": "54.239.192.0/19",
+      "region": "GLOBAL",
+      "service": "CLOUDFRONT"
+    },
+    {
+      "ip_prefix": "70.132.0.0/18",
+      "region": "GLOBAL",
+      "service": "CLOUDFRONT"
+    },
+    {
+      "ip_prefix": "13.32.0.0/15",
+      "region": "GLOBAL",
+      "service": "CLOUDFRONT"
+    },
+    {
+      "ip_prefix": "205.251.208.0/20",
+      "region": "GLOBAL",
+      "service": "CLOUDFRONT"
+    },
+    {
+      "ip_prefix": "13.224.0.0/14",
+      "region": "GLOBAL",
+      "service": "CLOUDFRONT"
+    },
+    {
+      "ip_prefix": "13.35.0.0/16",
+      "region": "GLOBAL",
+      "service": "CLOUDFRONT"
+    },
+    {
+      "ip_prefix": "204.246.164.0/22",
+      "region": "GLOBAL",
+      "service": "CLOUDFRONT"
+    },
+    {
+      "ip_prefix": "204.246.168.0/22",
+      "region": "GLOBAL",
+      "service": "CLOUDFRONT"
+    },
+    {
+      "ip_prefix": "71.152.0.0/17",
+      "region": "GLOBAL",
+      "service": "CLOUDFRONT"
+    },
+    {
+      "ip_prefix": "216.137.32.0/19",
+      "region": "GLOBAL",
+      "service": "CLOUDFRONT"
+    },
+    {
+      "ip_prefix": "205.251.249.0/24",
+      "region": "GLOBAL",
+      "service": "CLOUDFRONT"
+    },
+    {
+      "ip_prefix": "99.86.0.0/16",
+      "region": "GLOBAL",
+      "service": "CLOUDFRONT"
+    },
+    {
+      "ip_prefix": "52.46.0.0/18",
+      "region": "GLOBAL",
+      "service": "CLOUDFRONT"
+    },
+    {
+      "ip_prefix": "52.84.0.0/15",
+      "region": "GLOBAL",
+      "service": "CLOUDFRONT"
+    },
+    {
+      "ip_prefix": "204.246.173.0/24",
+      "region": "GLOBAL",
+      "service": "CLOUDFRONT"
+    },
+    {
+      "ip_prefix": "130.176.0.0/16",
+      "region": "GLOBAL",
+      "service": "CLOUDFRONT"
+    },
+    {
+      "ip_prefix": "205.251.200.0/21",
+      "region": "GLOBAL",
+      "service": "CLOUDFRONT"
+    },
+    {
+      "ip_prefix": "204.246.174.0/23",
+      "region": "GLOBAL",
+      "service": "CLOUDFRONT"
+    },
+    {
+      "ip_prefix": "64.252.128.0/18",
+      "region": "GLOBAL",
+      "service": "CLOUDFRONT"
+    },
+    {
+      "ip_prefix": "205.251.254.0/24",
+      "region": "GLOBAL",
+      "service": "CLOUDFRONT"
+    },
+    {
+      "ip_prefix": "143.204.0.0/16",
+      "region": "GLOBAL",
+      "service": "CLOUDFRONT"
+    },
+    {
+      "ip_prefix": "205.251.252.0/23",
+      "region": "GLOBAL",
+      "service": "CLOUDFRONT"
+    },
+    {
+      "ip_prefix": "204.246.176.0/20",
+      "region": "GLOBAL",
+      "service": "CLOUDFRONT"
+    },
+    {
+      "ip_prefix": "13.249.0.0/16",
+      "region": "GLOBAL",
+      "service": "CLOUDFRONT"
+    },
+    {
+      "ip_prefix": "54.240.128.0/18",
+      "region": "GLOBAL",
+      "service": "CLOUDFRONT"
+    },
+    {
+      "ip_prefix": "205.251.250.0/23",
+      "region": "GLOBAL",
+      "service": "CLOUDFRONT"
+    },
+    {
+      "ip_prefix": "52.222.128.0/17",
+      "region": "GLOBAL",
+      "service": "CLOUDFRONT"
+    },
+    {
+      "ip_prefix": "54.182.0.0/16",
+      "region": "GLOBAL",
+      "service": "CLOUDFRONT"
+    },
+    {
+      "ip_prefix": "54.192.0.0/16",
+      "region": "GLOBAL",
+      "service": "CLOUDFRONT"
+    },
+    {
+      "ip_prefix": "52.47.73.72/29",
+      "region": "eu-west-3",
+      "service": "CODEBUILD"
+    },
+    {
+      "ip_prefix": "13.55.255.216/29",
+      "region": "ap-southeast-2",
+      "service": "CODEBUILD"
+    },
+    {
+      "ip_prefix": "52.15.247.208/29",
+      "region": "us-east-2",
+      "service": "CODEBUILD"
+    },
+    {
+      "ip_prefix": "13.112.191.184/29",
+      "region": "ap-northeast-1",
+      "service": "CODEBUILD"
+    },
+    {
+      "ip_prefix": "34.250.63.248/29",
+      "region": "eu-west-1",
+      "service": "CODEBUILD"
+    },
+    {
+      "ip_prefix": "52.221.221.128/29",
+      "region": "ap-southeast-1",
+      "service": "CODEBUILD"
+    },
+    {
+      "ip_prefix": "13.127.70.136/29",
+      "region": "ap-south-1",
+      "service": "CODEBUILD"
+    },
+    {
+      "ip_prefix": "52.82.1.0/29",
+      "region": "cn-northwest-1",
+      "service": "CODEBUILD"
+    },
+    {
+      "ip_prefix": "177.71.207.16/29",
+      "region": "sa-east-1",
+      "service": "CODEBUILD"
+    },
+    {
+      "ip_prefix": "52.61.40.104/29",
+      "region": "us-gov-west-1",
+      "service": "CODEBUILD"
+    },
+    {
+      "ip_prefix": "13.124.145.16/29",
+      "region": "ap-northeast-2",
+      "service": "CODEBUILD"
+    },
+    {
+      "ip_prefix": "35.157.127.248/29",
+      "region": "eu-central-1",
+      "service": "CODEBUILD"
+    },
+    {
+      "ip_prefix": "35.182.14.48/29",
+      "region": "ca-central-1",
+      "service": "CODEBUILD"
+    },
+    {
+      "ip_prefix": "13.48.4.192/29",
+      "region": "eu-north-1",
+      "service": "CODEBUILD"
+    },
+    {
+      "ip_prefix": "35.176.92.32/29",
+      "region": "eu-west-2",
+      "service": "CODEBUILD"
+    },
+    {
+      "ip_prefix": "52.43.76.88/29",
+      "region": "us-west-2",
+      "service": "CODEBUILD"
+    },
+    {
+      "ip_prefix": "18.231.194.8/29",
+      "region": "sa-east-1",
+      "service": "CODEBUILD"
+    },
+    {
+      "ip_prefix": "52.80.198.136/29",
+      "region": "cn-north-1",
+      "service": "CODEBUILD"
+    },
+    {
+      "ip_prefix": "13.56.32.200/29",
+      "region": "us-west-1",
+      "service": "CODEBUILD"
+    },
+    {
+      "ip_prefix": "34.228.4.208/28",
+      "region": "us-east-1",
+      "service": "CODEBUILD"
+    },
+    {
+      "ip_prefix": "13.248.118.0/24",
+      "region": "eu-west-1",
+      "service": "GLOBALACCELERATOR"
+    },
+    {
+      "ip_prefix": "13.248.124.0/24",
+      "region": "us-east-1",
+      "service": "GLOBALACCELERATOR"
+    },
+    {
+      "ip_prefix": "13.248.106.0/24",
+      "region": "me-south-1",
+      "service": "GLOBALACCELERATOR"
+    },
+    {
+      "ip_prefix": "13.248.103.0/24",
+      "region": "us-east-1",
+      "service": "GLOBALACCELERATOR"
+    },
+    {
+      "ip_prefix": "13.248.100.0/24",
+      "region": "eu-north-1",
+      "service": "GLOBALACCELERATOR"
+    },
+    {
+      "ip_prefix": "15.197.2.0/24",
+      "region": "GLOBAL",
+      "service": "GLOBALACCELERATOR"
+    },
+    {
+      "ip_prefix": "13.248.123.0/24",
+      "region": "eu-central-1",
+      "service": "GLOBALACCELERATOR"
+    },
+    {
+      "ip_prefix": "13.248.99.0/24",
+      "region": "us-west-1",
+      "service": "GLOBALACCELERATOR"
+    },
+    {
+      "ip_prefix": "13.248.122.0/24",
+      "region": "eu-north-1",
+      "service": "GLOBALACCELERATOR"
+    },
+    {
+      "ip_prefix": "99.82.174.0/24",
+      "region": "ca-central-1",
+      "service": "GLOBALACCELERATOR"
+    },
+    {
+      "ip_prefix": "13.248.128.0/17",
+      "region": "GLOBAL",
+      "service": "GLOBALACCELERATOR"
+    },
+    {
+      "ip_prefix": "15.197.0.0/23",
+      "region": "GLOBAL",
+      "service": "GLOBALACCELERATOR"
+    },
+    {
+      "ip_prefix": "76.223.0.0/17",
+      "region": "GLOBAL",
+      "service": "GLOBALACCELERATOR"
+    },
+    {
+      "ip_prefix": "13.248.119.0/24",
+      "region": "eu-west-1",
+      "service": "GLOBALACCELERATOR"
+    },
+    {
+      "ip_prefix": "99.82.160.0/24",
+      "region": "ap-south-1",
+      "service": "GLOBALACCELERATOR"
+    },
+    {
+      "ip_prefix": "13.248.97.0/24",
+      "region": "eu-central-1",
+      "service": "GLOBALACCELERATOR"
+    },
+    {
+      "ip_prefix": "13.248.113.0/24",
+      "region": "eu-west-1",
+      "service": "GLOBALACCELERATOR"
+    },
+    {
+      "ip_prefix": "13.248.98.0/24",
+      "region": "ap-northeast-1",
+      "service": "GLOBALACCELERATOR"
+    },
+    {
+      "ip_prefix": "99.82.161.0/24",
+      "region": "eu-west-3",
+      "service": "GLOBALACCELERATOR"
+    },
+    {
+      "ip_prefix": "13.248.116.0/24",
+      "region": "us-east-1",
+      "service": "GLOBALACCELERATOR"
+    },
+    {
+      "ip_prefix": "99.82.171.0/24",
+      "region": "us-east-1",
+      "service": "GLOBALACCELERATOR"
+    },
+    {
+      "ip_prefix": "15.197.4.0/22",
+      "region": "GLOBAL",
+      "service": "GLOBALACCELERATOR"
+    },
+    {
+      "ip_prefix": "13.248.105.0/24",
+      "region": "ap-south-1",
+      "service": "GLOBALACCELERATOR"
+    },
+    {
+      "ip_prefix": "99.82.162.0/24",
+      "region": "eu-west-1",
+      "service": "GLOBALACCELERATOR"
+    },
+    {
+      "ip_prefix": "13.248.120.0/24",
+      "region": "eu-west-2",
+      "service": "GLOBALACCELERATOR"
+    },
+    {
+      "ip_prefix": "99.82.173.0/24",
+      "region": "ap-southeast-1",
+      "service": "GLOBALACCELERATOR"
+    },
+    {
+      "ip_prefix": "99.82.163.0/24",
+      "region": "eu-central-1",
+      "service": "GLOBALACCELERATOR"
+    },
+    {
+      "ip_prefix": "13.248.114.0/24",
+      "region": "sa-east-1",
+      "service": "GLOBALACCELERATOR"
+    },
+    {
+      "ip_prefix": "99.82.166.0/24",
+      "region": "us-east-1",
+      "service": "GLOBALACCELERATOR"
+    },
+    {
+      "ip_prefix": "75.2.0.0/17",
+      "region": "GLOBAL",
+      "service": "GLOBALACCELERATOR"
+    },
+    {
+      "ip_prefix": "13.248.117.0/24",
+      "region": "ap-south-1",
+      "service": "GLOBALACCELERATOR"
+    },
+    {
+      "ip_prefix": "99.82.175.0/24",
+      "region": "us-east-1",
+      "service": "GLOBALACCELERATOR"
+    },
+    {
+      "ip_prefix": "13.248.109.0/24",
+      "region": "ap-southeast-2",
+      "service": "GLOBALACCELERATOR"
+    },
+    {
+      "ip_prefix": "13.248.115.0/24",
+      "region": "ap-northeast-1",
+      "service": "GLOBALACCELERATOR"
+    },
+    {
+      "ip_prefix": "13.248.107.0/24",
+      "region": "ap-southeast-1",
+      "service": "GLOBALACCELERATOR"
+    },
+    {
+      "ip_prefix": "13.248.104.0/24",
+      "region": "sa-east-1",
+      "service": "GLOBALACCELERATOR"
+    },
+    {
+      "ip_prefix": "99.82.164.0/24",
+      "region": "sa-east-1",
+      "service": "GLOBALACCELERATOR"
+    },
+    {
+      "ip_prefix": "13.248.111.0/24",
+      "region": "us-east-2",
+      "service": "GLOBALACCELERATOR"
+    },
+    {
+      "ip_prefix": "99.82.168.0/24",
+      "region": "ap-northeast-2",
+      "service": "GLOBALACCELERATOR"
+    },
+    {
+      "ip_prefix": "99.83.128.0/17",
+      "region": "GLOBAL",
+      "service": "GLOBALACCELERATOR"
+    },
+    {
+      "ip_prefix": "13.248.112.0/24",
+      "region": "us-west-2",
+      "service": "GLOBALACCELERATOR"
+    },
+    {
+      "ip_prefix": "99.82.167.0/24",
+      "region": "us-east-1",
+      "service": "GLOBALACCELERATOR"
+    },
+    {
+      "ip_prefix": "13.248.101.0/24",
+      "region": "eu-west-2",
+      "service": "GLOBALACCELERATOR"
+    },
+    {
+      "ip_prefix": "13.248.108.0/24",
+      "region": "us-east-1",
+      "service": "GLOBALACCELERATOR"
+    },
+    {
+      "ip_prefix": "99.82.156.0/22",
+      "region": "GLOBAL",
+      "service": "GLOBALACCELERATOR"
+    },
+    {
+      "ip_prefix": "99.82.172.0/24",
+      "region": "us-west-1",
+      "service": "GLOBALACCELERATOR"
+    },
+    {
+      "ip_prefix": "13.248.96.0/24",
+      "region": "eu-west-1",
+      "service": "GLOBALACCELERATOR"
+    },
+    {
+      "ip_prefix": "99.82.169.0/24",
+      "region": "eu-west-2",
+      "service": "GLOBALACCELERATOR"
+    },
+    {
+      "ip_prefix": "99.82.165.0/24",
+      "region": "us-east-1",
+      "service": "GLOBALACCELERATOR"
+    },
+    {
+      "ip_prefix": "13.248.102.0/24",
+      "region": "ap-southeast-2",
+      "service": "GLOBALACCELERATOR"
+    },
+    {
+      "ip_prefix": "13.248.121.0/24",
+      "region": "eu-west-1",
+      "service": "GLOBALACCELERATOR"
+    },
+    {
+      "ip_prefix": "99.82.170.0/24",
+      "region": "ap-northeast-1",
+      "service": "GLOBALACCELERATOR"
+    },
+    {
+      "ip_prefix": "15.193.0.0/19",
+      "region": "GLOBAL",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "15.193.0.0/19",
+      "region": "GLOBAL",
+      "service": "AMAZON_CONNECT"
+    },
+    {
+      "ip_prefix": "15.177.77.0/24",
+      "region": "ap-northeast-3",
+      "service": "ROUTE53_HEALTHCHECKS_PUBLISHING"
+    },
+    {
+      "ip_prefix": "15.177.76.0/24",
+      "region": "ap-northeast-2",
+      "service": "ROUTE53_HEALTHCHECKS_PUBLISHING"
+    },
+    {
+      "ip_prefix": "15.177.74.0/24",
+      "region": "eu-west-3",
+      "service": "ROUTE53_HEALTHCHECKS_PUBLISHING"
+    },
+    {
+      "ip_prefix": "15.177.86.0/24",
+      "region": "ap-east-1",
+      "service": "ROUTE53_HEALTHCHECKS_PUBLISHING"
+    },
+    {
+      "ip_prefix": "15.177.91.0/24",
+      "region": "af-south-1",
+      "service": "ROUTE53_HEALTHCHECKS_PUBLISHING"
+    },
+    {
+      "ip_prefix": "15.177.82.0/24",
+      "region": "ap-southeast-1",
+      "service": "ROUTE53_HEALTHCHECKS_PUBLISHING"
+    },
+    {
+      "ip_prefix": "15.177.87.0/24",
+      "region": "me-south-1",
+      "service": "ROUTE53_HEALTHCHECKS_PUBLISHING"
+    },
+    {
+      "ip_prefix": "15.177.73.0/24",
+      "region": "ap-south-1",
+      "service": "ROUTE53_HEALTHCHECKS_PUBLISHING"
+    },
+    {
+      "ip_prefix": "15.177.70.0/23",
+      "region": "sa-east-1",
+      "service": "ROUTE53_HEALTHCHECKS_PUBLISHING"
+    },
+    {
+      "ip_prefix": "15.177.83.0/24",
+      "region": "ap-southeast-2",
+      "service": "ROUTE53_HEALTHCHECKS_PUBLISHING"
+    },
+    {
+      "ip_prefix": "15.177.88.0/24",
+      "region": "sa-east-1",
+      "service": "ROUTE53_HEALTHCHECKS_PUBLISHING"
+    },
+    {
+      "ip_prefix": "15.177.89.0/24",
+      "region": "eu-west-1",
+      "service": "ROUTE53_HEALTHCHECKS_PUBLISHING"
+    },
+    {
+      "ip_prefix": "15.177.64.0/23",
+      "region": "us-east-1",
+      "service": "ROUTE53_HEALTHCHECKS_PUBLISHING"
+    },
+    {
+      "ip_prefix": "15.177.80.0/24",
+      "region": "us-west-2",
+      "service": "ROUTE53_HEALTHCHECKS_PUBLISHING"
+    },
+    {
+      "ip_prefix": "15.177.68.0/23",
+      "region": "eu-central-1",
+      "service": "ROUTE53_HEALTHCHECKS_PUBLISHING"
+    },
+    {
+      "ip_prefix": "15.177.81.0/24",
+      "region": "us-west-1",
+      "service": "ROUTE53_HEALTHCHECKS_PUBLISHING"
+    },
+    {
+      "ip_prefix": "15.177.84.0/24",
+      "region": "ca-central-1",
+      "service": "ROUTE53_HEALTHCHECKS_PUBLISHING"
+    },
+    {
+      "ip_prefix": "15.177.75.0/24",
+      "region": "eu-west-1",
+      "service": "ROUTE53_HEALTHCHECKS_PUBLISHING"
+    },
+    {
+      "ip_prefix": "15.177.66.0/23",
+      "region": "us-east-2",
+      "service": "ROUTE53_HEALTHCHECKS_PUBLISHING"
+    },
+    {
+      "ip_prefix": "15.177.72.0/24",
+      "region": "eu-north-1",
+      "service": "ROUTE53_HEALTHCHECKS_PUBLISHING"
+    },
+    {
+      "ip_prefix": "15.177.78.0/24",
+      "region": "eu-west-2",
+      "service": "ROUTE53_HEALTHCHECKS_PUBLISHING"
+    },
+    {
+      "ip_prefix": "15.177.79.0/24",
+      "region": "ap-northeast-1",
+      "service": "ROUTE53_HEALTHCHECKS_PUBLISHING"
+    },
+    {
+      "ip_prefix": "15.177.85.0/24",
+      "region": "ap-east-1",
+      "service": "ROUTE53_HEALTHCHECKS_PUBLISHING"
+    },
+    {
+      "ip_prefix": "64.252.64.0/18",
+      "region": "GLOBAL",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "13.124.199.0/24",
+      "region": "ap-northeast-2",
+      "service": "CLOUDFRONT"
+    },
+    {
+      "ip_prefix": "34.226.14.0/24",
+      "region": "us-east-1",
+      "service": "CLOUDFRONT"
+    },
+    {
+      "ip_prefix": "52.15.127.128/26",
+      "region": "us-east-2",
+      "service": "CLOUDFRONT"
+    },
+    {
+      "ip_prefix": "35.158.136.0/24",
+      "region": "eu-central-1",
+      "service": "CLOUDFRONT"
+    },
+    {
+      "ip_prefix": "52.57.254.0/24",
+      "region": "eu-central-1",
+      "service": "CLOUDFRONT"
+    },
+    {
+      "ip_prefix": "18.216.170.128/25",
+      "region": "us-east-2",
+      "service": "CLOUDFRONT"
+    },
+    {
+      "ip_prefix": "13.52.204.0/23",
+      "region": "us-west-1",
+      "service": "CLOUDFRONT"
+    },
+    {
+      "ip_prefix": "13.54.63.128/26",
+      "region": "ap-southeast-2",
+      "service": "CLOUDFRONT"
+    },
+    {
+      "ip_prefix": "13.59.250.0/26",
+      "region": "us-east-2",
+      "service": "CLOUDFRONT"
+    },
+    {
+      "ip_prefix": "13.210.67.128/26",
+      "region": "ap-southeast-2",
+      "service": "CLOUDFRONT"
+    },
+    {
+      "ip_prefix": "35.167.191.128/26",
+      "region": "us-west-2",
+      "service": "CLOUDFRONT"
+    },
+    {
+      "ip_prefix": "52.47.139.0/24",
+      "region": "eu-west-3",
+      "service": "CLOUDFRONT"
+    },
+    {
+      "ip_prefix": "52.199.127.192/26",
+      "region": "ap-northeast-1",
+      "service": "CLOUDFRONT"
+    },
+    {
+      "ip_prefix": "52.212.248.0/26",
+      "region": "eu-west-1",
+      "service": "CLOUDFRONT"
+    },
+    {
+      "ip_prefix": "52.66.194.128/26",
+      "region": "ap-south-1",
+      "service": "CLOUDFRONT"
+    },
+    {
+      "ip_prefix": "13.113.203.0/24",
+      "region": "ap-northeast-1",
+      "service": "CLOUDFRONT"
+    },
+    {
+      "ip_prefix": "99.79.168.0/23",
+      "region": "ca-central-1",
+      "service": "CLOUDFRONT"
+    },
+    {
+      "ip_prefix": "34.195.252.0/24",
+      "region": "us-east-1",
+      "service": "CLOUDFRONT"
+    },
+    {
+      "ip_prefix": "35.162.63.192/26",
+      "region": "us-west-2",
+      "service": "CLOUDFRONT"
+    },
+    {
+      "ip_prefix": "34.223.12.224/27",
+      "region": "us-west-2",
+      "service": "CLOUDFRONT"
+    },
+    {
+      "ip_prefix": "52.56.127.0/25",
+      "region": "eu-west-2",
+      "service": "CLOUDFRONT"
+    },
+    {
+      "ip_prefix": "34.223.80.192/26",
+      "region": "us-west-2",
+      "service": "CLOUDFRONT"
+    },
+    {
+      "ip_prefix": "13.228.69.0/24",
+      "region": "ap-southeast-1",
+      "service": "CLOUDFRONT"
+    },
+    {
+      "ip_prefix": "34.216.51.0/25",
+      "region": "us-west-2",
+      "service": "CLOUDFRONT"
+    },
+    {
+      "ip_prefix": "3.231.2.0/25",
+      "region": "us-east-1",
+      "service": "CLOUDFRONT"
+    },
+    {
+      "ip_prefix": "54.233.255.128/26",
+      "region": "sa-east-1",
+      "service": "CLOUDFRONT"
+    },
+    {
+      "ip_prefix": "18.200.212.0/23",
+      "region": "eu-west-1",
+      "service": "CLOUDFRONT"
+    },
+    {
+      "ip_prefix": "64.252.64.0/18",
+      "region": "GLOBAL",
+      "service": "CLOUDFRONT"
+    },
+    {
+      "ip_prefix": "52.52.191.128/26",
+      "region": "us-west-1",
+      "service": "CLOUDFRONT"
+    },
+    {
+      "ip_prefix": "3.234.232.224/27",
+      "region": "us-east-1",
+      "service": "CLOUDFRONT"
+    },
+    {
+      "ip_prefix": "52.78.247.128/26",
+      "region": "ap-northeast-2",
+      "service": "CLOUDFRONT"
+    },
+    {
+      "ip_prefix": "52.220.191.0/26",
+      "region": "ap-southeast-1",
+      "service": "CLOUDFRONT"
+    },
+    {
+      "ip_prefix": "34.232.163.208/29",
+      "region": "us-east-1",
+      "service": "CLOUDFRONT"
+    },
+    {
+      "ip_prefix": "13.208.170.0/23",
+      "region": "ap-northeast-3",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "13.234.221.192/26",
+      "region": "ap-south-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "13.234.8.0/23",
+      "region": "ap-south-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "13.251.113.64/26",
+      "region": "ap-southeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "13.251.116.0/23",
+      "region": "ap-southeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "13.52.118.0/23",
+      "region": "us-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "13.52.146.192/26",
+      "region": "us-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "13.53.180.0/23",
+      "region": "eu-north-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "18.228.246.0/23",
+      "region": "sa-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "3.104.82.0/23",
+      "region": "ap-southeast-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "3.112.64.0/23",
+      "region": "ap-northeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "3.113.218.0/26",
+      "region": "ap-northeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "3.122.128.0/23",
+      "region": "eu-central-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "3.123.12.192/26",
+      "region": "eu-central-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "3.15.36.64/26",
+      "region": "us-east-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "3.17.136.0/23",
+      "region": "us-east-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "3.227.250.128/25",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "3.8.168.0/23",
+      "region": "eu-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "3.83.168.0/22",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "3.91.171.128/25",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "34.223.24.0/22",
+      "region": "us-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "34.223.45.0/25",
+      "region": "us-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "35.180.244.0/23",
+      "region": "eu-west-3",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "54.180.184.0/23",
+      "region": "ap-northeast-2",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "63.34.60.0/22",
+      "region": "eu-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "99.79.34.0/23",
+      "region": "ca-central-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "99.80.34.128/25",
+      "region": "eu-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ip_prefix": "108.128.160.0/23",
+      "region": "eu-west-1",
+      "service": "API_GATEWAY"
+    },
+    {
+      "ip_prefix": "108.128.162.0/24",
+      "region": "eu-west-1",
+      "service": "API_GATEWAY"
+    },
+    {
+      "ip_prefix": "13.208.180.0/24",
+      "region": "ap-northeast-3",
+      "service": "API_GATEWAY"
+    },
+    {
+      "ip_prefix": "13.235.228.0/24",
+      "region": "ap-south-1",
+      "service": "API_GATEWAY"
+    },
+    {
+      "ip_prefix": "13.235.6.0/23",
+      "region": "ap-south-1",
+      "service": "API_GATEWAY"
+    },
+    {
+      "ip_prefix": "13.48.74.0/24",
+      "region": "eu-north-1",
+      "service": "API_GATEWAY"
+    },
+    {
+      "ip_prefix": "13.52.201.0/24",
+      "region": "us-west-1",
+      "service": "API_GATEWAY"
+    },
+    {
+      "ip_prefix": "13.52.202.0/24",
+      "region": "us-west-1",
+      "service": "API_GATEWAY"
+    },
+    {
+      "ip_prefix": "15.164.156.0/23",
+      "region": "ap-northeast-2",
+      "service": "API_GATEWAY"
+    },
+    {
+      "ip_prefix": "18.138.134.128/25",
+      "region": "ap-southeast-1",
+      "service": "API_GATEWAY"
+    },
+    {
+      "ip_prefix": "18.138.244.0/23",
+      "region": "ap-southeast-1",
+      "service": "API_GATEWAY"
+    },
+    {
+      "ip_prefix": "18.144.76.128/25",
+      "region": "us-west-1",
+      "service": "API_GATEWAY"
+    },
+    {
+      "ip_prefix": "18.229.100.0/26",
+      "region": "sa-east-1",
+      "service": "API_GATEWAY"
+    },
+    {
+      "ip_prefix": "18.229.99.0/24",
+      "region": "sa-east-1",
+      "service": "API_GATEWAY"
+    },
+    {
+      "ip_prefix": "3.10.17.0/25",
+      "region": "eu-west-2",
+      "service": "API_GATEWAY"
+    },
+    {
+      "ip_prefix": "3.105.172.0/22",
+      "region": "ap-southeast-2",
+      "service": "API_GATEWAY"
+    },
+    {
+      "ip_prefix": "3.112.162.0/23",
+      "region": "ap-northeast-1",
+      "service": "API_GATEWAY"
+    },
+    {
+      "ip_prefix": "3.112.96.160/27",
+      "region": "ap-northeast-1",
+      "service": "API_GATEWAY"
+    },
+    {
+      "ip_prefix": "3.12.216.0/22",
+      "region": "us-east-2",
+      "service": "API_GATEWAY"
+    },
+    {
+      "ip_prefix": "3.123.14.0/24",
+      "region": "eu-central-1",
+      "service": "API_GATEWAY"
+    },
+    {
+      "ip_prefix": "3.123.15.0/25",
+      "region": "eu-central-1",
+      "service": "API_GATEWAY"
+    },
+    {
+      "ip_prefix": "3.15.35.0/24",
+      "region": "us-east-2",
+      "service": "API_GATEWAY"
+    },
+    {
+      "ip_prefix": "3.15.36.0/26",
+      "region": "us-east-2",
+      "service": "API_GATEWAY"
+    },
+    {
+      "ip_prefix": "3.216.135.0/24",
+      "region": "us-east-1",
+      "service": "API_GATEWAY"
+    },
+    {
+      "ip_prefix": "3.216.136.0/21",
+      "region": "us-east-1",
+      "service": "API_GATEWAY"
+    },
+    {
+      "ip_prefix": "3.216.144.0/23",
+      "region": "us-east-1",
+      "service": "API_GATEWAY"
+    },
+    {
+      "ip_prefix": "3.216.148.0/22",
+      "region": "us-east-1",
+      "service": "API_GATEWAY"
+    },
+    {
+      "ip_prefix": "3.9.94.0/24",
+      "region": "eu-west-2",
+      "service": "API_GATEWAY"
+    },
+    {
+      "ip_prefix": "34.223.68.0/22",
+      "region": "us-west-2",
+      "service": "API_GATEWAY"
+    },
+    {
+      "ip_prefix": "34.223.72.0/23",
+      "region": "us-west-2",
+      "service": "API_GATEWAY"
+    },
+    {
+      "ip_prefix": "34.223.74.0/25",
+      "region": "us-west-2",
+      "service": "API_GATEWAY"
+    },
+    {
+      "ip_prefix": "35.181.128.0/24",
+      "region": "eu-west-3",
+      "service": "API_GATEWAY"
+    },
+    {
+      "ip_prefix": "44.233.54.0/23",
+      "region": "us-west-2",
+      "service": "API_GATEWAY"
+    },
+    {
+      "ip_prefix": "99.79.126.0/24",
+      "region": "ca-central-1",
+      "service": "API_GATEWAY"
+    },
+    {
+      "ip_prefix": "13.210.2.192/26",
+      "region": "ap-southeast-2",
+      "service": "AMAZON_CONNECT"
+    },
+    {
+      "ip_prefix": "13.236.8.0/25",
+      "region": "ap-southeast-2",
+      "service": "AMAZON_CONNECT"
+    },
+    {
+      "ip_prefix": "18.182.96.64/26",
+      "region": "ap-northeast-1",
+      "service": "AMAZON_CONNECT"
+    },
+    {
+      "ip_prefix": "18.184.2.128/25",
+      "region": "eu-central-1",
+      "service": "AMAZON_CONNECT"
+    },
+    {
+      "ip_prefix": "18.233.213.128/25",
+      "region": "us-east-1",
+      "service": "AMAZON_CONNECT"
+    },
+    {
+      "ip_prefix": "18.236.61.0/25",
+      "region": "us-west-2",
+      "service": "AMAZON_CONNECT"
+    },
+    {
+      "ip_prefix": "35.158.127.64/26",
+      "region": "eu-central-1",
+      "service": "AMAZON_CONNECT"
+    },
+    {
+      "ip_prefix": "52.55.191.224/27",
+      "region": "us-east-1",
+      "service": "AMAZON_CONNECT"
+    },
+    {
+      "ip_prefix": "54.190.198.32/28",
+      "region": "us-west-2",
+      "service": "AMAZON_CONNECT"
+    },
+    {
+      "ip_prefix": "13.232.67.128/27",
+      "region": "ap-south-1",
+      "service": "CLOUD9"
+    },
+    {
+      "ip_prefix": "13.232.67.160/27",
+      "region": "ap-south-1",
+      "service": "CLOUD9"
+    },
+    {
+      "ip_prefix": "13.236.82.128/27",
+      "region": "ap-southeast-2",
+      "service": "CLOUD9"
+    },
+    {
+      "ip_prefix": "13.236.82.96/27",
+      "region": "ap-southeast-2",
+      "service": "CLOUD9"
+    },
+    {
+      "ip_prefix": "13.250.186.128/27",
+      "region": "ap-southeast-1",
+      "service": "CLOUD9"
+    },
+    {
+      "ip_prefix": "13.250.186.160/27",
+      "region": "ap-southeast-1",
+      "service": "CLOUD9"
+    },
+    {
+      "ip_prefix": "13.48.186.128/27",
+      "region": "eu-north-1",
+      "service": "CLOUD9"
+    },
+    {
+      "ip_prefix": "13.48.186.160/27",
+      "region": "eu-north-1",
+      "service": "CLOUD9"
+    },
+    {
+      "ip_prefix": "15.164.243.192/27",
+      "region": "ap-northeast-2",
+      "service": "CLOUD9"
+    },
+    {
+      "ip_prefix": "15.164.243.32/27",
+      "region": "ap-northeast-2",
+      "service": "CLOUD9"
+    },
+    {
+      "ip_prefix": "15.222.16.96/27",
+      "region": "ca-central-1",
+      "service": "CLOUD9"
+    },
+    {
+      "ip_prefix": "15.222.43.0/27",
+      "region": "ca-central-1",
+      "service": "CLOUD9"
+    },
+    {
+      "ip_prefix": "18.179.48.128/27",
+      "region": "ap-northeast-1",
+      "service": "CLOUD9"
+    },
+    {
+      "ip_prefix": "18.179.48.96/27",
+      "region": "ap-northeast-1",
+      "service": "CLOUD9"
+    },
+    {
+      "ip_prefix": "18.184.138.224/27",
+      "region": "eu-central-1",
+      "service": "CLOUD9"
+    },
+    {
+      "ip_prefix": "18.184.203.128/27",
+      "region": "eu-central-1",
+      "service": "CLOUD9"
+    },
+    {
+      "ip_prefix": "18.188.9.0/27",
+      "region": "us-east-2",
+      "service": "CLOUD9"
+    },
+    {
+      "ip_prefix": "18.188.9.32/27",
+      "region": "us-east-2",
+      "service": "CLOUD9"
+    },
+    {
+      "ip_prefix": "3.10.127.32/27",
+      "region": "eu-west-2",
+      "service": "CLOUD9"
+    },
+    {
+      "ip_prefix": "3.10.201.64/27",
+      "region": "eu-west-2",
+      "service": "CLOUD9"
+    },
+    {
+      "ip_prefix": "34.217.141.224/27",
+      "region": "us-west-2",
+      "service": "CLOUD9"
+    },
+    {
+      "ip_prefix": "34.218.119.32/27",
+      "region": "us-west-2",
+      "service": "CLOUD9"
+    },
+    {
+      "ip_prefix": "34.245.205.0/27",
+      "region": "eu-west-1",
+      "service": "CLOUD9"
+    },
+    {
+      "ip_prefix": "34.245.205.64/27",
+      "region": "eu-west-1",
+      "service": "CLOUD9"
+    },
+    {
+      "ip_prefix": "35.172.155.192/27",
+      "region": "us-east-1",
+      "service": "CLOUD9"
+    },
+    {
+      "ip_prefix": "35.172.155.96/27",
+      "region": "us-east-1",
+      "service": "CLOUD9"
+    },
+    {
+      "ip_prefix": "13.209.1.56/29",
+      "region": "ap-northeast-2",
+      "service": "EC2_INSTANCE_CONNECT"
+    },
+    {
+      "ip_prefix": "13.233.177.0/29",
+      "region": "ap-south-1",
+      "service": "EC2_INSTANCE_CONNECT"
+    },
+    {
+      "ip_prefix": "13.239.158.0/29",
+      "region": "ap-southeast-2",
+      "service": "EC2_INSTANCE_CONNECT"
+    },
+    {
+      "ip_prefix": "13.48.4.200/30",
+      "region": "eu-north-1",
+      "service": "EC2_INSTANCE_CONNECT"
+    },
+    {
+      "ip_prefix": "13.52.6.112/29",
+      "region": "us-west-1",
+      "service": "EC2_INSTANCE_CONNECT"
+    },
+    {
+      "ip_prefix": "18.202.216.48/29",
+      "region": "eu-west-1",
+      "service": "EC2_INSTANCE_CONNECT"
+    },
+    {
+      "ip_prefix": "18.206.107.24/29",
+      "region": "us-east-1",
+      "service": "EC2_INSTANCE_CONNECT"
+    },
+    {
+      "ip_prefix": "18.228.70.32/29",
+      "region": "sa-east-1",
+      "service": "EC2_INSTANCE_CONNECT"
+    },
+    {
+      "ip_prefix": "18.237.140.160/29",
+      "region": "us-west-2",
+      "service": "EC2_INSTANCE_CONNECT"
+    },
+    {
+      "ip_prefix": "3.0.5.32/29",
+      "region": "ap-southeast-1",
+      "service": "EC2_INSTANCE_CONNECT"
+    },
+    {
+      "ip_prefix": "3.112.23.0/29",
+      "region": "ap-northeast-1",
+      "service": "EC2_INSTANCE_CONNECT"
+    },
+    {
+      "ip_prefix": "3.120.181.40/29",
+      "region": "eu-central-1",
+      "service": "EC2_INSTANCE_CONNECT"
+    },
+    {
+      "ip_prefix": "3.16.146.0/29",
+      "region": "us-east-2",
+      "service": "EC2_INSTANCE_CONNECT"
+    },
+    {
+      "ip_prefix": "3.8.37.24/29",
+      "region": "eu-west-2",
+      "service": "EC2_INSTANCE_CONNECT"
+    },
+    {
+      "ip_prefix": "35.180.112.80/29",
+      "region": "eu-west-3",
+      "service": "EC2_INSTANCE_CONNECT"
+    },
+    {
+      "ip_prefix": "35.183.92.176/29",
+      "region": "ca-central-1",
+      "service": "EC2_INSTANCE_CONNECT"
+    },
+    {
+      "ip_prefix": "13.124.247.0/24",
+      "region": "ap-northeast-2",
+      "service": "WORKSPACES_GATEWAYS"
+    },
+    {
+      "ip_prefix": "3.217.228.0/22",
+      "region": "us-east-1",
+      "service": "WORKSPACES_GATEWAYS"
+    },
+    {
+      "ip_prefix": "35.176.32.0/24",
+      "region": "eu-west-2",
+      "service": "WORKSPACES_GATEWAYS"
+    },
+    {
+      "ip_prefix": "35.183.255.0/24",
+      "region": "ca-central-1",
+      "service": "WORKSPACES_GATEWAYS"
+    },
+    {
+      "ip_prefix": "52.19.124.0/23",
+      "region": "eu-west-1",
+      "service": "WORKSPACES_GATEWAYS"
+    },
+    {
+      "ip_prefix": "52.23.61.0/24",
+      "region": "us-east-1",
+      "service": "WORKSPACES_GATEWAYS"
+    },
+    {
+      "ip_prefix": "52.23.62.0/24",
+      "region": "us-east-1",
+      "service": "WORKSPACES_GATEWAYS"
+    },
+    {
+      "ip_prefix": "52.59.127.0/24",
+      "region": "eu-central-1",
+      "service": "WORKSPACES_GATEWAYS"
+    },
+    {
+      "ip_prefix": "52.76.127.0/24",
+      "region": "ap-southeast-1",
+      "service": "WORKSPACES_GATEWAYS"
+    },
+    {
+      "ip_prefix": "54.153.254.0/24",
+      "region": "ap-southeast-2",
+      "service": "WORKSPACES_GATEWAYS"
+    },
+    {
+      "ip_prefix": "54.233.204.0/24",
+      "region": "sa-east-1",
+      "service": "WORKSPACES_GATEWAYS"
+    },
+    {
+      "ip_prefix": "54.244.46.0/23",
+      "region": "us-west-2",
+      "service": "WORKSPACES_GATEWAYS"
+    },
+    {
+      "ip_prefix": "54.250.251.0/24",
+      "region": "ap-northeast-1",
+      "service": "WORKSPACES_GATEWAYS"
+    }
+  ],
+  "ipv6_prefixes": [
+    {
+      "ipv6_prefix": "2a05:d07c:2000::/40",
+      "region": "eu-west-3",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2600:9000:a300::/40",
+      "region": "GLOBAL",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2a05:d000:8000::/40",
+      "region": "eu-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2406:dafe:2000::/40",
+      "region": "ap-northeast-2",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2600:1f01:4860::/47",
+      "region": "ap-northeast-2",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2406:daff:8000::/40",
+      "region": "ap-southeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2600:1f13::/36",
+      "region": "us-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2406:da1a::/36",
+      "region": "ap-south-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2406:daf8:c000::/40",
+      "region": "ap-southeast-2",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2406:daf9:6000::/40",
+      "region": "ap-northeast-3",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2a05:d050:2000::/40",
+      "region": "eu-west-3",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2406:daa0:8000::/40",
+      "region": "ap-southeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2a05:d000:4000::/40",
+      "region": "eu-central-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2600:1ffc:8000::/40",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2620:107:300f::/64",
+      "region": "us-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2a05:d07c:8000::/40",
+      "region": "eu-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2406:da18::/36",
+      "region": "ap-southeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2406:dafa:2000::/40",
+      "region": "ap-northeast-2",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2400:6500:ff00::/64",
+      "region": "ap-southeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2a01:578:0:7000::/56",
+      "region": "eu-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2406:daf9:8000::/40",
+      "region": "ap-southeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2400:7fc0:8000::/36",
+      "region": "cn-north-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "240f:80ff:4000::/40",
+      "region": "cn-northwest-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2600:1f01:4822::/56",
+      "region": "eu-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2400:6500:0:7500::/56",
+      "region": "ap-south-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2600:1f01:48b0::/47",
+      "region": "ap-southeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2a05:d07e:e000::/40",
+      "region": "me-south-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2406:daa0:e000::/40",
+      "region": "ap-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2600:1f01:4840::/47",
+      "region": "sa-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2600:1f01:48d2::/47",
+      "region": "ap-southeast-2",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2a05:d050:e000::/40",
+      "region": "me-south-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2600:9000:a600::/40",
+      "region": "GLOBAL",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2a05:d07c:e000::/40",
+      "region": "me-south-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2600:9000:a500::/40",
+      "region": "GLOBAL",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2400:6500:0:7100::/56",
+      "region": "ap-northeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2a05:d050:c000::/40",
+      "region": "eu-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2404:c2c0:2800::/40",
+      "region": "cn-northwest-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2406:dafa:6000::/40",
+      "region": "ap-northeast-3",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2a05:d07f:c000::/40",
+      "region": "eu-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2406:dafa:a000::/40",
+      "region": "ap-south-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2600:1f14::/35",
+      "region": "us-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2620:107:4000:7000::/56",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2a05:d079:c000::/40",
+      "region": "eu-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2400:6500:100:7200::/56",
+      "region": "cn-northwest-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2406:dafa:4000::/40",
+      "region": "ap-northeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2406:daf9:a000::/40",
+      "region": "ap-south-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2600:1ffe:6000::/40",
+      "region": "us-east-2",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2406:da1e::/32",
+      "region": "ap-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2406:daa0:1000::/40",
+      "region": "af-south-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2600:1f00:e000::/40",
+      "region": "sa-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2600:1ffa:2000::/40",
+      "region": "us-gov-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2600:1ffa:6000::/40",
+      "region": "us-east-2",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2406:daf9:4000::/40",
+      "region": "ap-northeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2600:1ff9:4000::/40",
+      "region": "us-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2600:1ffc:e000::/40",
+      "region": "sa-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2a05:d050:8000::/40",
+      "region": "eu-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2406:daf8:1000::/40",
+      "region": "af-south-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2406:dafe:8000::/40",
+      "region": "ap-southeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2600:1f01:4820::/47",
+      "region": "eu-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2a05:d07e:8000::/40",
+      "region": "eu-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2406:dafc:4000::/40",
+      "region": "ap-northeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2406:daff:e000::/40",
+      "region": "ap-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2a05:d000:c000::/40",
+      "region": "eu-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2a05:d07f:e000::/40",
+      "region": "me-south-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2400:7fc0:2100::/40",
+      "region": "cn-north-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2600:9000:eee::/48",
+      "region": "GLOBAL",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2406:daa0:6000::/40",
+      "region": "ap-northeast-3",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2406:daf8:e000::/40",
+      "region": "ap-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2400:7fc0:2600::/40",
+      "region": "cn-north-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2600:1ffc:1000::/40",
+      "region": "ca-central-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2400:7fc0:2200::/40",
+      "region": "cn-north-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2620:107:4000:5::/64",
+      "region": "us-gov-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2600:1ff8:1000::/40",
+      "region": "ca-central-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2400:6500:0:7200::/56",
+      "region": "ap-southeast-2",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2600:1ff9:c000::/40",
+      "region": "us-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2600:1ffe:e000::/40",
+      "region": "sa-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2600:9000:aa00::/40",
+      "region": "GLOBAL",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2406:dafe:e000::/40",
+      "region": "ap-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2600:1fff:1000::/40",
+      "region": "ca-central-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2600:1f01:4870::/47",
+      "region": "eu-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2a05:d079:e000::/40",
+      "region": "me-south-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2620:108:d000::/44",
+      "region": "us-gov-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2600:1fff:4000::/40",
+      "region": "us-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2406:daff:4000::/40",
+      "region": "ap-northeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2a05:d07f:4000::/40",
+      "region": "eu-central-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2600:1fa0:4000::/40",
+      "region": "us-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2600:1f00:1000::/40",
+      "region": "ca-central-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2a05:d000:e000::/40",
+      "region": "me-south-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2a05:d050:4000::/40",
+      "region": "eu-central-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2600:1fa0:8000::/40",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2600:1ffe:8000::/40",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2406:da16::/36",
+      "region": "ap-northeast-3",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2406:daa0:c000::/40",
+      "region": "ap-southeast-2",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2620:107:4000:7200::/56",
+      "region": "us-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "240f:80fe:4000::/40",
+      "region": "cn-northwest-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2a05:d07e:2000::/40",
+      "region": "eu-west-3",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2400:7fc0:2400::/40",
+      "region": "cn-north-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2600:1ffa:c000::/40",
+      "region": "us-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2a05:d07f:2000::/40",
+      "region": "eu-west-3",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2a05:d016::/36",
+      "region": "eu-north-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2406:dafa:c000::/40",
+      "region": "ap-southeast-2",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2406:da00:8000::/40",
+      "region": "ap-southeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2600:1f00:c000::/40",
+      "region": "us-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2620:107:4000:7100::/56",
+      "region": "us-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2404:c2c0::/40",
+      "region": "cn-northwest-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2406:dafe:4000::/40",
+      "region": "ap-northeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2600:1f01:4810::/47",
+      "region": "eu-west-3",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2600:1f12::/36",
+      "region": "us-gov-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2600:1ffc:4000::/40",
+      "region": "us-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2600:1f01:4830::/47",
+      "region": "eu-central-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2600:1fa0:e000::/40",
+      "region": "sa-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2600:1ffc:2000::/40",
+      "region": "us-gov-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2a05:d079:8000::/40",
+      "region": "eu-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2404:c2c0:2f00::/40",
+      "region": "cn-northwest-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2a05:d050:6000::/40",
+      "region": "eu-north-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2406:daf9:e000::/40",
+      "region": "ap-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2600:9000:ab00::/40",
+      "region": "GLOBAL",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2406:daf8:8000::/40",
+      "region": "ap-southeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2600:1ffe:1000::/40",
+      "region": "ca-central-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2600:1ff8:4000::/40",
+      "region": "us-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2a05:d07f:6000::/40",
+      "region": "eu-north-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "240f:80a0:8000::/40",
+      "region": "cn-north-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2600:1fff:e000::/40",
+      "region": "sa-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2406:daf9:c000::/40",
+      "region": "ap-southeast-2",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2600:1f1f::/36",
+      "region": "us-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2a05:d078:2000::/40",
+      "region": "eu-west-3",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2406:dafc:a000::/40",
+      "region": "ap-south-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2406:dafe:6000::/40",
+      "region": "ap-northeast-3",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2406:daff:c000::/40",
+      "region": "ap-southeast-2",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2404:c2c0:2200::/40",
+      "region": "cn-northwest-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2400:7fc0:2800::/40",
+      "region": "cn-north-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2406:da00:2000::/40",
+      "region": "ap-northeast-2",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2600:1ff8:5000::/36",
+      "region": "us-gov-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2600:9000:af00::/40",
+      "region": "GLOBAL",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2600:1fff:8000::/40",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2600:9000:a100::/40",
+      "region": "GLOBAL",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2600:1f1c::/36",
+      "region": "us-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2600:9000:4000::/36",
+      "region": "GLOBAL",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2a05:d012::/36",
+      "region": "eu-west-3",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2620:107:4008::/45",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2404:c2c0:2600::/40",
+      "region": "cn-northwest-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2600:1f00:6000::/40",
+      "region": "us-east-2",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2600:9000:ac00::/40",
+      "region": "GLOBAL",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "240f:80fc:4000::/40",
+      "region": "cn-northwest-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2600:1f11::/36",
+      "region": "ca-central-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "240f:80f9:8000::/40",
+      "region": "cn-north-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2600:1ffe:2000::/40",
+      "region": "us-gov-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2406:dafa:e000::/40",
+      "region": "ap-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2600:1ffe:5000::/40",
+      "region": "us-gov-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2a05:d07c:4000::/40",
+      "region": "eu-central-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2406:daff:2000::/40",
+      "region": "ap-northeast-2",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "240f:8014::/36",
+      "region": "cn-northwest-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "240f:80a0:4000::/40",
+      "region": "cn-northwest-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2404:c2c0:2a00::/40",
+      "region": "cn-northwest-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2600:1ffa:4000::/40",
+      "region": "us-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2a05:d078:8000::/40",
+      "region": "eu-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2a05:d079:4000::/40",
+      "region": "eu-central-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "240f:80f8:4000::/40",
+      "region": "cn-northwest-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2600:9000:3000::/36",
+      "region": "GLOBAL",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2404:c2c0:2100::/40",
+      "region": "cn-northwest-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2600:9000:f000::/36",
+      "region": "GLOBAL",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2804:800:0:7000::/56",
+      "region": "sa-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2600:1f00:8000::/40",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2600:1f01:4850::/47",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2600:1f01:48a0::/47",
+      "region": "us-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2600:9000:fff::/48",
+      "region": "GLOBAL",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2400:7fc0:2f00::/40",
+      "region": "cn-north-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "240f:80fa:8000::/40",
+      "region": "cn-north-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2600:1ff9:e000::/40",
+      "region": "sa-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "240f:80f9:4000::/40",
+      "region": "cn-northwest-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2600:1f1e::/36",
+      "region": "sa-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2620:108:7000::/44",
+      "region": "us-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2406:da00:e000::/40",
+      "region": "ap-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2600:9000:a400::/40",
+      "region": "GLOBAL",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2a05:d079:2000::/40",
+      "region": "eu-west-3",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2600:1ffa:8000::/40",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "240f:80fc:8000::/40",
+      "region": "cn-north-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2600:1f01:48d0::/47",
+      "region": "eu-north-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2600:9000:a800::/40",
+      "region": "GLOBAL",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2a05:d01e::/36",
+      "region": "me-south-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2600:1fa0:6000::/40",
+      "region": "us-east-2",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2600:1fff:c000::/40",
+      "region": "us-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2406:daf9:1000::/40",
+      "region": "af-south-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2600:1fff:2000::/40",
+      "region": "us-gov-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2a05:d07a:c000::/40",
+      "region": "eu-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2600:1f01:4844::/47",
+      "region": "us-east-2",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2600:1fa0:c000::/40",
+      "region": "us-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2400:6700:ff00::/64",
+      "region": "ap-northeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2403:b300:ff00::/64",
+      "region": "ap-southeast-2",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2406:daa0:2000::/40",
+      "region": "ap-northeast-2",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2600:1f16::/36",
+      "region": "us-east-2",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2404:c2c0:200::/40",
+      "region": "cn-northwest-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2406:dafe:1000::/40",
+      "region": "af-south-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2a05:d078:c000::/40",
+      "region": "eu-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2a05:d07a:2000::/40",
+      "region": "eu-west-3",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2a05:d07a:6000::/40",
+      "region": "eu-north-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2600:1f60:6000::/40",
+      "region": "us-east-2",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2400:7fc0::/40",
+      "region": "cn-north-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2406:daff:a000::/40",
+      "region": "ap-south-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2600:1f00:4000::/40",
+      "region": "us-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2600:1fa0:2000::/40",
+      "region": "us-gov-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2a05:d078:e000::/40",
+      "region": "me-south-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2600:1ff9:1000::/40",
+      "region": "ca-central-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2406:daf8:2000::/40",
+      "region": "ap-northeast-2",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2406:dafc:2000::/40",
+      "region": "ap-northeast-2",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2600:1ff8:6000::/40",
+      "region": "us-east-2",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2600:1ffe:4000::/40",
+      "region": "us-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2406:dafc:6000::/40",
+      "region": "ap-northeast-3",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2600:1f01:48e0::/47",
+      "region": "me-south-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2406:daf8:a000::/40",
+      "region": "ap-south-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2620:107:4000:40::/64",
+      "region": "us-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2400:6500:0:7700::/56",
+      "region": "af-south-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2600:1f00:2000::/40",
+      "region": "us-gov-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2600:9000:2000::/36",
+      "region": "GLOBAL",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2600:1ffa:1000::/40",
+      "region": "ca-central-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2400:6500:0:7400::/56",
+      "region": "ap-northeast-2",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2400:7fc0:2a00::/40",
+      "region": "cn-north-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2600:9000:1000::/36",
+      "region": "GLOBAL",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2a05:d07f:8000::/40",
+      "region": "eu-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "240f:8018::/36",
+      "region": "cn-north-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2600:1ffa:5000::/40",
+      "region": "us-gov-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2a01:578:13::/64",
+      "region": "eu-central-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2406:da00:a000::/40",
+      "region": "ap-south-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2600:1fa0:1000::/40",
+      "region": "ca-central-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2600:1ffc:c000::/40",
+      "region": "us-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2600:1f01:4880::/47",
+      "region": "ap-northeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2620:107:4007::/64",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2a05:d07c:6000::/40",
+      "region": "eu-north-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2600:1ff9:2000::/40",
+      "region": "us-gov-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2600:9000:a900::/40",
+      "region": "GLOBAL",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2a05:d07a:4000::/40",
+      "region": "eu-central-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2620:107:4000:7400::/56",
+      "region": "us-gov-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2406:dafc:e000::/40",
+      "region": "ap-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2a01:578:0:7100::/56",
+      "region": "eu-central-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2600:1fa0:5000::/40",
+      "region": "us-gov-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "240f:8000:4000::/40",
+      "region": "cn-northwest-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2a05:d07e:6000::/40",
+      "region": "eu-north-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2406:daf8:6000::/40",
+      "region": "ap-northeast-3",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2400:7fc0:200::/40",
+      "region": "cn-north-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2400:6500:0:7000::/56",
+      "region": "ap-southeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2406:dafa:8000::/40",
+      "region": "ap-southeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2600:1ff9:5000::/40",
+      "region": "us-gov-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2600:1ff8:8000::/40",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2600:1ff8:2000::/40",
+      "region": "us-gov-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2600:1f15::/32",
+      "region": "us-gov-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2400:7fc0:2c00::/40",
+      "region": "cn-north-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2600:1f01:4800::/47",
+      "region": "ap-south-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2a05:d078:4000::/40",
+      "region": "eu-central-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2a05:d07a:8000::/40",
+      "region": "eu-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2a05:d07e:c000::/40",
+      "region": "eu-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2406:da00:c000::/40",
+      "region": "ap-southeast-2",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2406:dafc:1000::/40",
+      "region": "af-south-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2600:1fff:3000::/40",
+      "region": "us-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2406:da14::/36",
+      "region": "ap-northeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2600:1ff9:8000::/40",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2a05:d078:6000::/40",
+      "region": "eu-north-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2406:daff:1000::/40",
+      "region": "af-south-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2a05:d000:2000::/40",
+      "region": "eu-west-3",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2600:1ffe:c000::/40",
+      "region": "us-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2a05:d07c:c000::/40",
+      "region": "eu-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2406:da00:1000::/40",
+      "region": "af-south-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2406:dafc:c000::/40",
+      "region": "ap-southeast-2",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2600:9000:ae00::/40",
+      "region": "GLOBAL",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2a05:d07e:4000::/40",
+      "region": "eu-central-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2600:1ff8:c000::/40",
+      "region": "us-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2600:9000:ddd::/48",
+      "region": "GLOBAL",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2406:da1c::/36",
+      "region": "ap-southeast-2",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2406:da00:6000::/40",
+      "region": "ap-northeast-3",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2406:daa0:4000::/40",
+      "region": "ap-northeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2406:daf9:2000::/40",
+      "region": "ap-northeast-2",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2804:800:ff00::/64",
+      "region": "sa-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2a05:d079:6000::/40",
+      "region": "eu-north-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2406:da00:4000::/40",
+      "region": "ap-northeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2620:107:4000:7a00::/56",
+      "region": "us-gov-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2404:c2c0:2400::/40",
+      "region": "cn-northwest-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2600:1ffa:e000::/40",
+      "region": "sa-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2600:1ffc:6000::/40",
+      "region": "us-east-2",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2406:da11::/36",
+      "region": "af-south-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "240f:8000:8000::/40",
+      "region": "cn-north-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2600:9000:ad00::/40",
+      "region": "GLOBAL",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2a05:d018::/36",
+      "region": "eu-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "240f:80ff:8000::/40",
+      "region": "cn-north-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2600:1f01:48c0::/47",
+      "region": "ca-central-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2a05:d01c::/36",
+      "region": "eu-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2406:dafc:8000::/40",
+      "region": "ap-southeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2600:1ff9:6000::/40",
+      "region": "us-east-2",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2a05:d000:6000::/40",
+      "region": "eu-north-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2404:c2c0:2c00::/40",
+      "region": "cn-northwest-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "240f:80f8:8000::/40",
+      "region": "cn-north-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2600:9000:a200::/40",
+      "region": "GLOBAL",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2620:107:4000:7800::/56",
+      "region": "ca-central-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2a01:578:0:7200::/56",
+      "region": "eu-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2404:c2c0:8000::/36",
+      "region": "cn-northwest-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2600:1ff0:6000::/40",
+      "region": "us-east-2",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2a05:d014::/36",
+      "region": "eu-central-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2406:daf8:4000::/40",
+      "region": "ap-northeast-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2406:dafe:c000::/40",
+      "region": "ap-southeast-2",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2600:1f18::/33",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2400:6500:0:7300::/56",
+      "region": "ap-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2600:1ff8:e000::/40",
+      "region": "sa-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "240f:80fe:8000::/40",
+      "region": "cn-north-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2620:107:4000:7700::/56",
+      "region": "us-east-2",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2406:daa0:a000::/40",
+      "region": "ap-south-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2406:dafe:a000::/40",
+      "region": "ap-south-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2600:1fff:5000::/40",
+      "region": "us-gov-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2406:da12::/36",
+      "region": "ap-northeast-2",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2600:1f01:4890::/47",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2600:1f01:4874::/47",
+      "region": "us-west-2",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2406:daff:6000::/40",
+      "region": "ap-northeast-3",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2600:1f00:5000::/40",
+      "region": "us-gov-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2406:da00:ff00::/64",
+      "region": "us-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2600:9000:5300::/40",
+      "region": "GLOBAL",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2600:9000:a700::/40",
+      "region": "GLOBAL",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2a05:d07a:e000::/40",
+      "region": "me-south-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2600:1ffc:5000::/40",
+      "region": "us-gov-east-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2600:1fff:6000::/40",
+      "region": "us-east-2",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "240f:80fa:4000::/40",
+      "region": "cn-northwest-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2a01:578:3::/64",
+      "region": "eu-west-1",
+      "service": "AMAZON"
+    },
+    {
+      "ipv6_prefix": "2804:800:ff00::b147:cf80/122",
+      "region": "sa-east-1",
+      "service": "ROUTE53_HEALTHCHECKS"
+    },
+    {
+      "ipv6_prefix": "2400:6700:ff00::36f8:dc00/122",
+      "region": "ap-northeast-1",
+      "service": "ROUTE53_HEALTHCHECKS"
+    },
+    {
+      "ipv6_prefix": "2403:b300:ff00::36fc:4f80/122",
+      "region": "ap-southeast-2",
+      "service": "ROUTE53_HEALTHCHECKS"
+    },
+    {
+      "ipv6_prefix": "2406:da00:ff00::36f3:1fc0/122",
+      "region": "us-east-1",
+      "service": "ROUTE53_HEALTHCHECKS"
+    },
+    {
+      "ipv6_prefix": "2406:da14:fff:f800::/53",
+      "region": "ap-northeast-1",
+      "service": "ROUTE53_HEALTHCHECKS"
+    },
+    {
+      "ipv6_prefix": "2400:6500:ff00::36ff:fec0/122",
+      "region": "ap-southeast-1",
+      "service": "ROUTE53_HEALTHCHECKS"
+    },
+    {
+      "ipv6_prefix": "2a01:578:3::36e4:1000/122",
+      "region": "eu-west-1",
+      "service": "ROUTE53_HEALTHCHECKS"
+    },
+    {
+      "ipv6_prefix": "2600:1f14:fff:f800::/53",
+      "region": "us-west-2",
+      "service": "ROUTE53_HEALTHCHECKS"
+    },
+    {
+      "ipv6_prefix": "2600:1f14:7ff:f800::/53",
+      "region": "us-west-2",
+      "service": "ROUTE53_HEALTHCHECKS"
+    },
+    {
+      "ipv6_prefix": "2406:da1c:7ff:f800::/53",
+      "region": "ap-southeast-2",
+      "service": "ROUTE53_HEALTHCHECKS"
+    },
+    {
+      "ipv6_prefix": "2600:1f18:7fff:f800::/53",
+      "region": "us-east-1",
+      "service": "ROUTE53_HEALTHCHECKS"
+    },
+    {
+      "ipv6_prefix": "2600:1f18:3fff:f800::/53",
+      "region": "us-east-1",
+      "service": "ROUTE53_HEALTHCHECKS"
+    },
+    {
+      "ipv6_prefix": "2804:800:ff00::36e8:2840/122",
+      "region": "sa-east-1",
+      "service": "ROUTE53_HEALTHCHECKS"
+    },
+    {
+      "ipv6_prefix": "2620:107:300f::36f1:2040/122",
+      "region": "us-west-1",
+      "service": "ROUTE53_HEALTHCHECKS"
+    },
+    {
+      "ipv6_prefix": "2620:108:700f::36f4:34c0/122",
+      "region": "us-west-2",
+      "service": "ROUTE53_HEALTHCHECKS"
+    },
+    {
+      "ipv6_prefix": "2620:107:300f::36b7:ff80/122",
+      "region": "us-west-1",
+      "service": "ROUTE53_HEALTHCHECKS"
+    },
+    {
+      "ipv6_prefix": "2403:b300:ff00::36fc:fec0/122",
+      "region": "ap-southeast-2",
+      "service": "ROUTE53_HEALTHCHECKS"
+    },
+    {
+      "ipv6_prefix": "2a05:d018:7ff:f800::/53",
+      "region": "eu-west-1",
+      "service": "ROUTE53_HEALTHCHECKS"
+    },
+    {
+      "ipv6_prefix": "2406:da00:ff00::6b17:ff00/122",
+      "region": "us-east-1",
+      "service": "ROUTE53_HEALTHCHECKS"
+    },
+    {
+      "ipv6_prefix": "2400:6700:ff00::36fa:fdc0/122",
+      "region": "ap-northeast-1",
+      "service": "ROUTE53_HEALTHCHECKS"
+    },
+    {
+      "ipv6_prefix": "2406:da18:fff:f800::/53",
+      "region": "ap-southeast-1",
+      "service": "ROUTE53_HEALTHCHECKS"
+    },
+    {
+      "ipv6_prefix": "2620:108:700f::36f5:a800/122",
+      "region": "us-west-2",
+      "service": "ROUTE53_HEALTHCHECKS"
+    },
+    {
+      "ipv6_prefix": "2600:1f1c:7ff:f800::/53",
+      "region": "us-west-1",
+      "service": "ROUTE53_HEALTHCHECKS"
+    },
+    {
+      "ipv6_prefix": "2406:da1c:fff:f800::/53",
+      "region": "ap-southeast-2",
+      "service": "ROUTE53_HEALTHCHECKS"
+    },
+    {
+      "ipv6_prefix": "2600:1f1e:fff:f800::/53",
+      "region": "sa-east-1",
+      "service": "ROUTE53_HEALTHCHECKS"
+    },
+    {
+      "ipv6_prefix": "2600:1f1c:fff:f800::/53",
+      "region": "us-west-1",
+      "service": "ROUTE53_HEALTHCHECKS"
+    },
+    {
+      "ipv6_prefix": "2406:da14:7ff:f800::/53",
+      "region": "ap-northeast-1",
+      "service": "ROUTE53_HEALTHCHECKS"
+    },
+    {
+      "ipv6_prefix": "2a05:d018:fff:f800::/53",
+      "region": "eu-west-1",
+      "service": "ROUTE53_HEALTHCHECKS"
+    },
+    {
+      "ipv6_prefix": "2400:6500:ff00::36fb:1f80/122",
+      "region": "ap-southeast-1",
+      "service": "ROUTE53_HEALTHCHECKS"
+    },
+    {
+      "ipv6_prefix": "2406:da18:7ff:f800::/53",
+      "region": "ap-southeast-1",
+      "service": "ROUTE53_HEALTHCHECKS"
+    },
+    {
+      "ipv6_prefix": "2600:1f1e:7ff:f800::/53",
+      "region": "sa-east-1",
+      "service": "ROUTE53_HEALTHCHECKS"
+    },
+    {
+      "ipv6_prefix": "2a01:578:3::b022:9fc0/122",
+      "region": "eu-west-1",
+      "service": "ROUTE53_HEALTHCHECKS"
+    },
+    {
+      "ipv6_prefix": "2406:daf8:c000::/40",
+      "region": "ap-southeast-2",
+      "service": "S3"
+    },
+    {
+      "ipv6_prefix": "2406:daf9:6000::/40",
+      "region": "ap-northeast-3",
+      "service": "S3"
+    },
+    {
+      "ipv6_prefix": "2a05:d050:2000::/40",
+      "region": "eu-west-3",
+      "service": "S3"
+    },
+    {
+      "ipv6_prefix": "2406:daa0:8000::/40",
+      "region": "ap-southeast-1",
+      "service": "S3"
+    },
+    {
+      "ipv6_prefix": "2406:dafa:2000::/40",
+      "region": "ap-northeast-2",
+      "service": "S3"
+    },
+    {
+      "ipv6_prefix": "2406:daf9:8000::/40",
+      "region": "ap-southeast-1",
+      "service": "S3"
+    },
+    {
+      "ipv6_prefix": "2406:daa0:e000::/40",
+      "region": "ap-east-1",
+      "service": "S3"
+    },
+    {
+      "ipv6_prefix": "2a05:d050:e000::/40",
+      "region": "me-south-1",
+      "service": "S3"
+    },
+    {
+      "ipv6_prefix": "2a05:d050:c000::/40",
+      "region": "eu-west-2",
+      "service": "S3"
+    },
+    {
+      "ipv6_prefix": "2404:c2c0:2800::/40",
+      "region": "cn-northwest-1",
+      "service": "S3"
+    },
+    {
+      "ipv6_prefix": "2406:dafa:6000::/40",
+      "region": "ap-northeast-3",
+      "service": "S3"
+    },
+    {
+      "ipv6_prefix": "2406:dafa:a000::/40",
+      "region": "ap-south-1",
+      "service": "S3"
+    },
+    {
+      "ipv6_prefix": "2a05:d079:c000::/40",
+      "region": "eu-west-2",
+      "service": "S3"
+    },
+    {
+      "ipv6_prefix": "2406:dafa:4000::/40",
+      "region": "ap-northeast-1",
+      "service": "S3"
+    },
+    {
+      "ipv6_prefix": "2406:daf9:a000::/40",
+      "region": "ap-south-1",
+      "service": "S3"
+    },
+    {
+      "ipv6_prefix": "2406:daa0:1000::/40",
+      "region": "af-south-1",
+      "service": "S3"
+    },
+    {
+      "ipv6_prefix": "2600:1ffa:2000::/40",
+      "region": "us-gov-west-1",
+      "service": "S3"
+    },
+    {
+      "ipv6_prefix": "2600:1ffa:6000::/40",
+      "region": "us-east-2",
+      "service": "S3"
+    },
+    {
+      "ipv6_prefix": "2406:daf9:4000::/40",
+      "region": "ap-northeast-1",
+      "service": "S3"
+    },
+    {
+      "ipv6_prefix": "2600:1ff9:4000::/40",
+      "region": "us-west-2",
+      "service": "S3"
+    },
+    {
+      "ipv6_prefix": "2a05:d050:8000::/40",
+      "region": "eu-west-1",
+      "service": "S3"
+    },
+    {
+      "ipv6_prefix": "2406:daf8:1000::/40",
+      "region": "af-south-1",
+      "service": "S3"
+    },
+    {
+      "ipv6_prefix": "2406:daa0:6000::/40",
+      "region": "ap-northeast-3",
+      "service": "S3"
+    },
+    {
+      "ipv6_prefix": "2406:daf8:e000::/40",
+      "region": "ap-east-1",
+      "service": "S3"
+    },
+    {
+      "ipv6_prefix": "2600:1ff8:1000::/40",
+      "region": "ca-central-1",
+      "service": "S3"
+    },
+    {
+      "ipv6_prefix": "2600:1ff9:c000::/40",
+      "region": "us-west-1",
+      "service": "S3"
+    },
+    {
+      "ipv6_prefix": "2a05:d079:e000::/40",
+      "region": "me-south-1",
+      "service": "S3"
+    },
+    {
+      "ipv6_prefix": "2600:1fa0:4000::/40",
+      "region": "us-west-2",
+      "service": "S3"
+    },
+    {
+      "ipv6_prefix": "2a05:d050:4000::/40",
+      "region": "eu-central-1",
+      "service": "S3"
+    },
+    {
+      "ipv6_prefix": "2600:1fa0:8000::/40",
+      "region": "us-east-1",
+      "service": "S3"
+    },
+    {
+      "ipv6_prefix": "2406:daa0:c000::/40",
+      "region": "ap-southeast-2",
+      "service": "S3"
+    },
+    {
+      "ipv6_prefix": "2400:7fc0:2400::/40",
+      "region": "cn-north-1",
+      "service": "S3"
+    },
+    {
+      "ipv6_prefix": "2600:1ffa:c000::/40",
+      "region": "us-west-1",
+      "service": "S3"
+    },
+    {
+      "ipv6_prefix": "2406:dafa:c000::/40",
+      "region": "ap-southeast-2",
+      "service": "S3"
+    },
+    {
+      "ipv6_prefix": "2600:1fa0:e000::/40",
+      "region": "sa-east-1",
+      "service": "S3"
+    },
+    {
+      "ipv6_prefix": "2a05:d079:8000::/40",
+      "region": "eu-west-1",
+      "service": "S3"
+    },
+    {
+      "ipv6_prefix": "2406:daf9:e000::/40",
+      "region": "ap-east-1",
+      "service": "S3"
+    },
+    {
+      "ipv6_prefix": "2406:daf8:8000::/40",
+      "region": "ap-southeast-1",
+      "service": "S3"
+    },
+    {
+      "ipv6_prefix": "2600:1ff8:4000::/40",
+      "region": "us-west-2",
+      "service": "S3"
+    },
+    {
+      "ipv6_prefix": "240f:80a0:8000::/40",
+      "region": "cn-north-1",
+      "service": "S3"
+    },
+    {
+      "ipv6_prefix": "2406:daf9:c000::/40",
+      "region": "ap-southeast-2",
+      "service": "S3"
+    },
+    {
+      "ipv6_prefix": "2a05:d078:2000::/40",
+      "region": "eu-west-3",
+      "service": "S3"
+    },
+    {
+      "ipv6_prefix": "2400:7fc0:2800::/40",
+      "region": "cn-north-1",
+      "service": "S3"
+    },
+    {
+      "ipv6_prefix": "2600:1ff8:5000::/36",
+      "region": "us-gov-east-1",
+      "service": "S3"
+    },
+    {
+      "ipv6_prefix": "240f:80f9:8000::/40",
+      "region": "cn-north-1",
+      "service": "S3"
+    },
+    {
+      "ipv6_prefix": "2406:dafa:e000::/40",
+      "region": "ap-east-1",
+      "service": "S3"
+    },
+    {
+      "ipv6_prefix": "240f:80a0:4000::/40",
+      "region": "cn-northwest-1",
+      "service": "S3"
+    },
+    {
+      "ipv6_prefix": "2600:1ffa:4000::/40",
+      "region": "us-west-2",
+      "service": "S3"
+    },
+    {
+      "ipv6_prefix": "2a05:d078:8000::/40",
+      "region": "eu-west-1",
+      "service": "S3"
+    },
+    {
+      "ipv6_prefix": "2a05:d079:4000::/40",
+      "region": "eu-central-1",
+      "service": "S3"
+    },
+    {
+      "ipv6_prefix": "240f:80f8:4000::/40",
+      "region": "cn-northwest-1",
+      "service": "S3"
+    },
+    {
+      "ipv6_prefix": "240f:80fa:8000::/40",
+      "region": "cn-north-1",
+      "service": "S3"
+    },
+    {
+      "ipv6_prefix": "2600:1ff9:e000::/40",
+      "region": "sa-east-1",
+      "service": "S3"
+    },
+    {
+      "ipv6_prefix": "240f:80f9:4000::/40",
+      "region": "cn-northwest-1",
+      "service": "S3"
+    },
+    {
+      "ipv6_prefix": "2a05:d079:2000::/40",
+      "region": "eu-west-3",
+      "service": "S3"
+    },
+    {
+      "ipv6_prefix": "2600:1ffa:8000::/40",
+      "region": "us-east-1",
+      "service": "S3"
+    },
+    {
+      "ipv6_prefix": "2600:1fa0:6000::/40",
+      "region": "us-east-2",
+      "service": "S3"
+    },
+    {
+      "ipv6_prefix": "2406:daf9:1000::/40",
+      "region": "af-south-1",
+      "service": "S3"
+    },
+    {
+      "ipv6_prefix": "2a05:d07a:c000::/40",
+      "region": "eu-west-2",
+      "service": "S3"
+    },
+    {
+      "ipv6_prefix": "2600:1fa0:c000::/40",
+      "region": "us-west-1",
+      "service": "S3"
+    },
+    {
+      "ipv6_prefix": "2406:daa0:2000::/40",
+      "region": "ap-northeast-2",
+      "service": "S3"
+    },
+    {
+      "ipv6_prefix": "2404:c2c0:200::/40",
+      "region": "cn-northwest-1",
+      "service": "S3"
+    },
+    {
+      "ipv6_prefix": "2a05:d078:c000::/40",
+      "region": "eu-west-2",
+      "service": "S3"
+    },
+    {
+      "ipv6_prefix": "2a05:d07a:2000::/40",
+      "region": "eu-west-3",
+      "service": "S3"
+    },
+    {
+      "ipv6_prefix": "2a05:d07a:6000::/40",
+      "region": "eu-north-1",
+      "service": "S3"
+    },
+    {
+      "ipv6_prefix": "2600:1f60:6000::/40",
+      "region": "us-east-2",
+      "service": "S3"
+    },
+    {
+      "ipv6_prefix": "2600:1fa0:2000::/40",
+      "region": "us-gov-west-1",
+      "service": "S3"
+    },
+    {
+      "ipv6_prefix": "2a05:d078:e000::/40",
+      "region": "me-south-1",
+      "service": "S3"
+    },
+    {
+      "ipv6_prefix": "2600:1ff9:1000::/40",
+      "region": "ca-central-1",
+      "service": "S3"
+    },
+    {
+      "ipv6_prefix": "2406:daf8:2000::/40",
+      "region": "ap-northeast-2",
+      "service": "S3"
+    },
+    {
+      "ipv6_prefix": "2600:1ff8:6000::/40",
+      "region": "us-east-2",
+      "service": "S3"
+    },
+    {
+      "ipv6_prefix": "2406:daf8:a000::/40",
+      "region": "ap-south-1",
+      "service": "S3"
+    },
+    {
+      "ipv6_prefix": "2600:1ffa:1000::/40",
+      "region": "ca-central-1",
+      "service": "S3"
+    },
+    {
+      "ipv6_prefix": "2600:1ffa:5000::/40",
+      "region": "us-gov-east-1",
+      "service": "S3"
+    },
+    {
+      "ipv6_prefix": "2600:1fa0:1000::/40",
+      "region": "ca-central-1",
+      "service": "S3"
+    },
+    {
+      "ipv6_prefix": "2600:1ff9:2000::/40",
+      "region": "us-gov-west-1",
+      "service": "S3"
+    },
+    {
+      "ipv6_prefix": "2a05:d07a:4000::/40",
+      "region": "eu-central-1",
+      "service": "S3"
+    },
+    {
+      "ipv6_prefix": "2600:1fa0:5000::/40",
+      "region": "us-gov-east-1",
+      "service": "S3"
+    },
+    {
+      "ipv6_prefix": "2406:daf8:6000::/40",
+      "region": "ap-northeast-3",
+      "service": "S3"
+    },
+    {
+      "ipv6_prefix": "2400:7fc0:200::/40",
+      "region": "cn-north-1",
+      "service": "S3"
+    },
+    {
+      "ipv6_prefix": "2406:dafa:8000::/40",
+      "region": "ap-southeast-1",
+      "service": "S3"
+    },
+    {
+      "ipv6_prefix": "2600:1ff9:5000::/40",
+      "region": "us-gov-east-1",
+      "service": "S3"
+    },
+    {
+      "ipv6_prefix": "2600:1ff8:8000::/40",
+      "region": "us-east-1",
+      "service": "S3"
+    },
+    {
+      "ipv6_prefix": "2600:1ff8:2000::/40",
+      "region": "us-gov-west-1",
+      "service": "S3"
+    },
+    {
+      "ipv6_prefix": "2400:7fc0:2c00::/40",
+      "region": "cn-north-1",
+      "service": "S3"
+    },
+    {
+      "ipv6_prefix": "2a05:d078:4000::/40",
+      "region": "eu-central-1",
+      "service": "S3"
+    },
+    {
+      "ipv6_prefix": "2a05:d07a:8000::/40",
+      "region": "eu-west-1",
+      "service": "S3"
+    },
+    {
+      "ipv6_prefix": "2600:1ff9:8000::/40",
+      "region": "us-east-1",
+      "service": "S3"
+    },
+    {
+      "ipv6_prefix": "2a05:d078:6000::/40",
+      "region": "eu-north-1",
+      "service": "S3"
+    },
+    {
+      "ipv6_prefix": "2600:1ff8:c000::/40",
+      "region": "us-west-1",
+      "service": "S3"
+    },
+    {
+      "ipv6_prefix": "2406:daa0:4000::/40",
+      "region": "ap-northeast-1",
+      "service": "S3"
+    },
+    {
+      "ipv6_prefix": "2406:daf9:2000::/40",
+      "region": "ap-northeast-2",
+      "service": "S3"
+    },
+    {
+      "ipv6_prefix": "2a05:d079:6000::/40",
+      "region": "eu-north-1",
+      "service": "S3"
+    },
+    {
+      "ipv6_prefix": "2404:c2c0:2400::/40",
+      "region": "cn-northwest-1",
+      "service": "S3"
+    },
+    {
+      "ipv6_prefix": "2600:1ffa:e000::/40",
+      "region": "sa-east-1",
+      "service": "S3"
+    },
+    {
+      "ipv6_prefix": "2600:1ff9:6000::/40",
+      "region": "us-east-2",
+      "service": "S3"
+    },
+    {
+      "ipv6_prefix": "2404:c2c0:2c00::/40",
+      "region": "cn-northwest-1",
+      "service": "S3"
+    },
+    {
+      "ipv6_prefix": "240f:80f8:8000::/40",
+      "region": "cn-north-1",
+      "service": "S3"
+    },
+    {
+      "ipv6_prefix": "2600:1ff0:6000::/40",
+      "region": "us-east-2",
+      "service": "S3"
+    },
+    {
+      "ipv6_prefix": "2406:daf8:4000::/40",
+      "region": "ap-northeast-1",
+      "service": "S3"
+    },
+    {
+      "ipv6_prefix": "2600:1ff8:e000::/40",
+      "region": "sa-east-1",
+      "service": "S3"
+    },
+    {
+      "ipv6_prefix": "2406:daa0:a000::/40",
+      "region": "ap-south-1",
+      "service": "S3"
+    },
+    {
+      "ipv6_prefix": "2a05:d07a:e000::/40",
+      "region": "me-south-1",
+      "service": "S3"
+    },
+    {
+      "ipv6_prefix": "240f:80fa:4000::/40",
+      "region": "cn-northwest-1",
+      "service": "S3"
+    },
+    {
+      "ipv6_prefix": "2a05:d000:8000::/40",
+      "region": "eu-west-1",
+      "service": "EC2"
+    },
+    {
+      "ipv6_prefix": "2406:daff:8000::/40",
+      "region": "ap-southeast-1",
+      "service": "EC2"
+    },
+    {
+      "ipv6_prefix": "2600:1f13::/36",
+      "region": "us-west-2",
+      "service": "EC2"
+    },
+    {
+      "ipv6_prefix": "2406:da1a::/36",
+      "region": "ap-south-1",
+      "service": "EC2"
+    },
+    {
+      "ipv6_prefix": "2a05:d000:4000::/40",
+      "region": "eu-central-1",
+      "service": "EC2"
+    },
+    {
+      "ipv6_prefix": "2620:107:300f::/64",
+      "region": "us-west-1",
+      "service": "EC2"
+    },
+    {
+      "ipv6_prefix": "2406:da18::/36",
+      "region": "ap-southeast-1",
+      "service": "EC2"
+    },
+    {
+      "ipv6_prefix": "2400:6500:ff00::/64",
+      "region": "ap-southeast-1",
+      "service": "EC2"
+    },
+    {
+      "ipv6_prefix": "2400:7fc0:8000::/36",
+      "region": "cn-north-1",
+      "service": "EC2"
+    },
+    {
+      "ipv6_prefix": "240f:80ff:4000::/40",
+      "region": "cn-northwest-1",
+      "service": "EC2"
+    },
+    {
+      "ipv6_prefix": "2a05:d07f:c000::/40",
+      "region": "eu-west-2",
+      "service": "EC2"
+    },
+    {
+      "ipv6_prefix": "2600:1f14::/35",
+      "region": "us-west-2",
+      "service": "EC2"
+    },
+    {
+      "ipv6_prefix": "2406:da1e::/32",
+      "region": "ap-east-1",
+      "service": "EC2"
+    },
+    {
+      "ipv6_prefix": "2600:1f00:e000::/40",
+      "region": "sa-east-1",
+      "service": "EC2"
+    },
+    {
+      "ipv6_prefix": "2406:daff:e000::/40",
+      "region": "ap-east-1",
+      "service": "EC2"
+    },
+    {
+      "ipv6_prefix": "2a05:d000:c000::/40",
+      "region": "eu-west-2",
+      "service": "EC2"
+    },
+    {
+      "ipv6_prefix": "2a05:d07f:e000::/40",
+      "region": "me-south-1",
+      "service": "EC2"
+    },
+    {
+      "ipv6_prefix": "2400:7fc0:2100::/40",
+      "region": "cn-north-1",
+      "service": "EC2"
+    },
+    {
+      "ipv6_prefix": "2400:7fc0:2200::/40",
+      "region": "cn-north-1",
+      "service": "EC2"
+    },
+    {
+      "ipv6_prefix": "2600:1fff:1000::/40",
+      "region": "ca-central-1",
+      "service": "EC2"
+    },
+    {
+      "ipv6_prefix": "2600:1fff:4000::/40",
+      "region": "us-west-2",
+      "service": "EC2"
+    },
+    {
+      "ipv6_prefix": "2406:daff:4000::/40",
+      "region": "ap-northeast-1",
+      "service": "EC2"
+    },
+    {
+      "ipv6_prefix": "2a05:d07f:4000::/40",
+      "region": "eu-central-1",
+      "service": "EC2"
+    },
+    {
+      "ipv6_prefix": "2600:1f00:1000::/40",
+      "region": "ca-central-1",
+      "service": "EC2"
+    },
+    {
+      "ipv6_prefix": "2a05:d000:e000::/40",
+      "region": "me-south-1",
+      "service": "EC2"
+    },
+    {
+      "ipv6_prefix": "2406:da16::/36",
+      "region": "ap-northeast-3",
+      "service": "EC2"
+    },
+    {
+      "ipv6_prefix": "2a05:d07f:2000::/40",
+      "region": "eu-west-3",
+      "service": "EC2"
+    },
+    {
+      "ipv6_prefix": "2a05:d016::/36",
+      "region": "eu-north-1",
+      "service": "EC2"
+    },
+    {
+      "ipv6_prefix": "2406:da00:8000::/40",
+      "region": "ap-southeast-1",
+      "service": "EC2"
+    },
+    {
+      "ipv6_prefix": "2600:1f00:c000::/40",
+      "region": "us-west-1",
+      "service": "EC2"
+    },
+    {
+      "ipv6_prefix": "2404:c2c0::/40",
+      "region": "cn-northwest-1",
+      "service": "EC2"
+    },
+    {
+      "ipv6_prefix": "2600:1f12::/36",
+      "region": "us-gov-west-1",
+      "service": "EC2"
+    },
+    {
+      "ipv6_prefix": "2404:c2c0:2f00::/40",
+      "region": "cn-northwest-1",
+      "service": "EC2"
+    },
+    {
+      "ipv6_prefix": "2a05:d07f:6000::/40",
+      "region": "eu-north-1",
+      "service": "EC2"
+    },
+    {
+      "ipv6_prefix": "2600:1fff:e000::/40",
+      "region": "sa-east-1",
+      "service": "EC2"
+    },
+    {
+      "ipv6_prefix": "2600:1f1f::/36",
+      "region": "us-west-2",
+      "service": "EC2"
+    },
+    {
+      "ipv6_prefix": "2406:daff:c000::/40",
+      "region": "ap-southeast-2",
+      "service": "EC2"
+    },
+    {
+      "ipv6_prefix": "2404:c2c0:2200::/40",
+      "region": "cn-northwest-1",
+      "service": "EC2"
+    },
+    {
+      "ipv6_prefix": "2406:da00:2000::/40",
+      "region": "ap-northeast-2",
+      "service": "EC2"
+    },
+    {
+      "ipv6_prefix": "2600:1fff:8000::/40",
+      "region": "us-east-1",
+      "service": "EC2"
+    },
+    {
+      "ipv6_prefix": "2600:1f1c::/36",
+      "region": "us-west-1",
+      "service": "EC2"
+    },
+    {
+      "ipv6_prefix": "2a05:d012::/36",
+      "region": "eu-west-3",
+      "service": "EC2"
+    },
+    {
+      "ipv6_prefix": "2600:1f00:6000::/40",
+      "region": "us-east-2",
+      "service": "EC2"
+    },
+    {
+      "ipv6_prefix": "2620:108:700f::/64",
+      "region": "us-west-2",
+      "service": "EC2"
+    },
+    {
+      "ipv6_prefix": "2600:1f11::/36",
+      "region": "ca-central-1",
+      "service": "EC2"
+    },
+    {
+      "ipv6_prefix": "2406:daff:2000::/40",
+      "region": "ap-northeast-2",
+      "service": "EC2"
+    },
+    {
+      "ipv6_prefix": "240f:8014::/36",
+      "region": "cn-northwest-1",
+      "service": "EC2"
+    },
+    {
+      "ipv6_prefix": "2404:c2c0:2100::/40",
+      "region": "cn-northwest-1",
+      "service": "EC2"
+    },
+    {
+      "ipv6_prefix": "2600:1f00:8000::/40",
+      "region": "us-east-1",
+      "service": "EC2"
+    },
+    {
+      "ipv6_prefix": "2400:7fc0:2f00::/40",
+      "region": "cn-north-1",
+      "service": "EC2"
+    },
+    {
+      "ipv6_prefix": "2600:1f1e::/36",
+      "region": "sa-east-1",
+      "service": "EC2"
+    },
+    {
+      "ipv6_prefix": "2406:da00:e000::/40",
+      "region": "ap-east-1",
+      "service": "EC2"
+    },
+    {
+      "ipv6_prefix": "2a05:d01e::/36",
+      "region": "me-south-1",
+      "service": "EC2"
+    },
+    {
+      "ipv6_prefix": "2600:1fff:c000::/40",
+      "region": "us-west-1",
+      "service": "EC2"
+    },
+    {
+      "ipv6_prefix": "2600:1fff:2000::/40",
+      "region": "us-gov-west-1",
+      "service": "EC2"
+    },
+    {
+      "ipv6_prefix": "2400:6700:ff00::/64",
+      "region": "ap-northeast-1",
+      "service": "EC2"
+    },
+    {
+      "ipv6_prefix": "2403:b300:ff00::/64",
+      "region": "ap-southeast-2",
+      "service": "EC2"
+    },
+    {
+      "ipv6_prefix": "2600:1f16::/36",
+      "region": "us-east-2",
+      "service": "EC2"
+    },
+    {
+      "ipv6_prefix": "2600:1f60:6000::/40",
+      "region": "us-east-2",
+      "service": "EC2"
+    },
+    {
+      "ipv6_prefix": "2400:7fc0::/40",
+      "region": "cn-north-1",
+      "service": "EC2"
+    },
+    {
+      "ipv6_prefix": "2406:daff:a000::/40",
+      "region": "ap-south-1",
+      "service": "EC2"
+    },
+    {
+      "ipv6_prefix": "2600:1f00:4000::/40",
+      "region": "us-west-2",
+      "service": "EC2"
+    },
+    {
+      "ipv6_prefix": "2600:1f00:2000::/40",
+      "region": "us-gov-west-1",
+      "service": "EC2"
+    },
+    {
+      "ipv6_prefix": "2a05:d07f:8000::/40",
+      "region": "eu-west-1",
+      "service": "EC2"
+    },
+    {
+      "ipv6_prefix": "240f:8018::/36",
+      "region": "cn-north-1",
+      "service": "EC2"
+    },
+    {
+      "ipv6_prefix": "2a01:578:13::/64",
+      "region": "eu-central-1",
+      "service": "EC2"
+    },
+    {
+      "ipv6_prefix": "2406:da00:a000::/40",
+      "region": "ap-south-1",
+      "service": "EC2"
+    },
+    {
+      "ipv6_prefix": "2620:107:4007::/64",
+      "region": "us-east-1",
+      "service": "EC2"
+    },
+    {
+      "ipv6_prefix": "240f:8000:4000::/40",
+      "region": "cn-northwest-1",
+      "service": "EC2"
+    },
+    {
+      "ipv6_prefix": "2600:1f15::/32",
+      "region": "us-gov-east-1",
+      "service": "EC2"
+    },
+    {
+      "ipv6_prefix": "2406:da00:c000::/40",
+      "region": "ap-southeast-2",
+      "service": "EC2"
+    },
+    {
+      "ipv6_prefix": "2600:1fff:3000::/40",
+      "region": "us-west-2",
+      "service": "EC2"
+    },
+    {
+      "ipv6_prefix": "2406:da14::/36",
+      "region": "ap-northeast-1",
+      "service": "EC2"
+    },
+    {
+      "ipv6_prefix": "2406:daff:1000::/40",
+      "region": "af-south-1",
+      "service": "EC2"
+    },
+    {
+      "ipv6_prefix": "2a05:d000:2000::/40",
+      "region": "eu-west-3",
+      "service": "EC2"
+    },
+    {
+      "ipv6_prefix": "2406:da00:1000::/40",
+      "region": "af-south-1",
+      "service": "EC2"
+    },
+    {
+      "ipv6_prefix": "2620:108:d00f::/64",
+      "region": "us-gov-west-1",
+      "service": "EC2"
+    },
+    {
+      "ipv6_prefix": "2406:da1c::/36",
+      "region": "ap-southeast-2",
+      "service": "EC2"
+    },
+    {
+      "ipv6_prefix": "2406:da00:6000::/40",
+      "region": "ap-northeast-3",
+      "service": "EC2"
+    },
+    {
+      "ipv6_prefix": "2804:800:ff00::/64",
+      "region": "sa-east-1",
+      "service": "EC2"
+    },
+    {
+      "ipv6_prefix": "2406:da00:4000::/40",
+      "region": "ap-northeast-1",
+      "service": "EC2"
+    },
+    {
+      "ipv6_prefix": "2406:da11::/36",
+      "region": "af-south-1",
+      "service": "EC2"
+    },
+    {
+      "ipv6_prefix": "240f:8000:8000::/40",
+      "region": "cn-north-1",
+      "service": "EC2"
+    },
+    {
+      "ipv6_prefix": "2a05:d018::/36",
+      "region": "eu-west-1",
+      "service": "EC2"
+    },
+    {
+      "ipv6_prefix": "240f:80ff:8000::/40",
+      "region": "cn-north-1",
+      "service": "EC2"
+    },
+    {
+      "ipv6_prefix": "2a05:d01c::/36",
+      "region": "eu-west-2",
+      "service": "EC2"
+    },
+    {
+      "ipv6_prefix": "2a05:d000:6000::/40",
+      "region": "eu-north-1",
+      "service": "EC2"
+    },
+    {
+      "ipv6_prefix": "2404:c2c0:8000::/36",
+      "region": "cn-northwest-1",
+      "service": "EC2"
+    },
+    {
+      "ipv6_prefix": "2600:1ff0:6000::/40",
+      "region": "us-east-2",
+      "service": "EC2"
+    },
+    {
+      "ipv6_prefix": "2a05:d014::/36",
+      "region": "eu-central-1",
+      "service": "EC2"
+    },
+    {
+      "ipv6_prefix": "2600:1f18::/33",
+      "region": "us-east-1",
+      "service": "EC2"
+    },
+    {
+      "ipv6_prefix": "2600:1fff:5000::/40",
+      "region": "us-gov-east-1",
+      "service": "EC2"
+    },
+    {
+      "ipv6_prefix": "2406:da12::/36",
+      "region": "ap-northeast-2",
+      "service": "EC2"
+    },
+    {
+      "ipv6_prefix": "2406:daff:6000::/40",
+      "region": "ap-northeast-3",
+      "service": "EC2"
+    },
+    {
+      "ipv6_prefix": "2600:1f00:5000::/40",
+      "region": "us-gov-east-1",
+      "service": "EC2"
+    },
+    {
+      "ipv6_prefix": "2406:da00:ff00::/64",
+      "region": "us-east-1",
+      "service": "EC2"
+    },
+    {
+      "ipv6_prefix": "2600:1fff:6000::/40",
+      "region": "us-east-2",
+      "service": "EC2"
+    },
+    {
+      "ipv6_prefix": "2a01:578:3::/64",
+      "region": "eu-west-1",
+      "service": "EC2"
+    },
+    {
+      "ipv6_prefix": "2600:9000:eee::/48",
+      "region": "GLOBAL",
+      "service": "CLOUDFRONT"
+    },
+    {
+      "ipv6_prefix": "2600:9000:4000::/36",
+      "region": "GLOBAL",
+      "service": "CLOUDFRONT"
+    },
+    {
+      "ipv6_prefix": "2600:9000:3000::/36",
+      "region": "GLOBAL",
+      "service": "CLOUDFRONT"
+    },
+    {
+      "ipv6_prefix": "2600:9000:f000::/36",
+      "region": "GLOBAL",
+      "service": "CLOUDFRONT"
+    },
+    {
+      "ipv6_prefix": "2600:9000:fff::/48",
+      "region": "GLOBAL",
+      "service": "CLOUDFRONT"
+    },
+    {
+      "ipv6_prefix": "2600:9000:2000::/36",
+      "region": "GLOBAL",
+      "service": "CLOUDFRONT"
+    },
+    {
+      "ipv6_prefix": "2600:9000:1000::/36",
+      "region": "GLOBAL",
+      "service": "CLOUDFRONT"
+    },
+    {
+      "ipv6_prefix": "2600:9000:ddd::/48",
+      "region": "GLOBAL",
+      "service": "CLOUDFRONT"
+    },
+    {
+      "ipv6_prefix": "2600:9000:5300::/40",
+      "region": "GLOBAL",
+      "service": "CLOUDFRONT"
+    }
+  ]
+}

--- a/apps/greencheck/management/commands/update_aws_ip_ranges.py
+++ b/apps/greencheck/management/commands/update_aws_ip_ranges.py
@@ -1,0 +1,119 @@
+import json
+import requests
+from ipaddress import IPv4Address, IPv6Address
+from apps.greencheck.models import GreencheckIp
+from apps.accounts.models import Hostingprovider
+
+from django.core.management.base import BaseCommand
+from django.db import connection
+
+class Command(BaseCommand):
+    help = "Update IP ranges for cloud providers that publish them"
+
+    def handle(self, *args, **options):
+        pass
+
+
+class AmazonCloudProvider:
+
+    def __init__(self, *args, **kwargs):
+        if kwargs.get('green_regions'):
+            self.green_regions = kwargs.get('green_regions')
+        else:
+            self.green_regions = (
+            ('Amazon US West', 'us-west-2', 696),
+            ('Amazon EU (Frankfurt)', 'eu-central-1', 697),
+            ('Amazon EU (Ireland)', 'eu-west-1', 698),
+            ('Amazon AWS GovCloud (USA)','us-gov-west-1', 699),
+            ('Amazon Montreal', 'ca-central-1', 700),
+        )
+
+    def update_ranges(self):
+
+        iprs = self.fetch_ip_ranges()
+
+        for region in self.green_regions:
+            _, aws_code, host_id = region
+            green_ipv4s = self.pullout_green_regions(iprs, region)
+            hoster = Hostingprovider.objects.get(pk=host_id)
+
+            self.add_ip_ranges_to_hoster(hoster, green_ipv4s)
+
+        # for region in green_regions:
+        #     hoster = self.find_hoster_by_region(region)
+        #     self.add_ip_ranges_to_hoster(hoster)
+
+        # we need to do this for ipv4, and then ipv6
+
+        pass
+
+    def fetch_ip_ranges(self):
+        aws_endpoint = "https://ip-ranges.amazonaws.com/ip-ranges.json"
+        return requests.get(aws_endpoint).json()
+
+    def pullout_green_ips(self, ip_ranges, region, ip_version=None):
+
+        if ip_version == "ipv6":
+            prefix = ['ipv6_prefixes']
+        else:
+            prefix = "prefixes"
+
+        return [
+            aws_ip['ip_prefix'] for aws_ip in ip_ranges[prefix]
+            if aws_ip['region'] == region
+        ]
+
+
+    def ip_ranges_for_hoster(self, ip_ranges, ip_version="ipv4"):
+        if ip_version == "ipv6":
+            ip_addy = ipaddress.IPv6Network
+        else:
+            ip_addy = ipaddress.IPv6Network
+
+        ips_for_hoster = []
+
+        for ipr in ip_ranges:
+            network = ip_addy(ipr)
+            # first, last = network[0], network[-1]
+            ips.append(network)
+
+        return ips_for_hoster
+
+
+    def update_hoster(self, hoster: Hostingprovider, first: IPv4Address, last: IPv4Address):
+        # use the ORM to update the deets for the corresponding hoster
+        gcip = GreencheckIp(
+            active=True,
+            ip_start=first,
+            ip_end=last,
+            hostingprovider=hoster
+        )
+        gcip.save()
+
+
+def ip_ranges_for_hoster(ip_ranges, ip_version="ipv4"):
+        if ip_version == "ipv6":
+            ip_addy = ipaddress.IPv6Network
+        else:
+            ip_addy = ipaddress.IPv4Network
+
+        ips_for_hoster = []
+
+        for ipr in ip_ranges:
+            network = ip_addy(ipr)
+
+            ips_for_hoster.append(network)
+
+        return ips_for_hoster
+
+
+def update_hoster(self, hoster: Hostingprovider, ip_range: IPv4Address):
+        first, last = ip_range[0], ip_range[-1]
+        # use the ORM to update the deets for the corresponding hoster
+        return GreencheckIp.update_or_create(
+            active=True,
+            ip_start=first,
+            ip_end=last,
+            hostingprovider=hoster
+        )
+

--- a/apps/greencheck/management/commands/update_aws_ip_ranges.py
+++ b/apps/greencheck/management/commands/update_aws_ip_ranges.py
@@ -1,6 +1,6 @@
 import json
 import requests
-from ipaddress import IPv4Address, IPv6Address
+import ipaddress
 from apps.greencheck.models import GreencheckIp
 from apps.accounts.models import Hostingprovider
 
@@ -54,7 +54,7 @@ class AmazonCloudProvider:
     def pullout_green_ips(self, ip_ranges, region, ip_version=None):
 
         if ip_version == "ipv6":
-            prefix = ['ipv6_prefixes']
+            prefix = 'ipv6_prefixes'
         else:
             prefix = "prefixes"
 
@@ -68,19 +68,19 @@ class AmazonCloudProvider:
         if ip_version == "ipv6":
             ip_addy = ipaddress.IPv6Network
         else:
-            ip_addy = ipaddress.IPv6Network
+            ip_addy = ipaddress.IPv4Network
 
         ips_for_hoster = []
 
         for ipr in ip_ranges:
             network = ip_addy(ipr)
-            # first, last = network[0], network[-1]
-            ips.append(network)
+
+            ips_for_hoster.append(network)
 
         return ips_for_hoster
 
 
-    def update_hoster(self, hoster: Hostingprovider, first: IPv4Address, last: IPv4Address):
+    def update_hoster(self, hoster: Hostingprovider, first: ipaddress.IPv4Address, last: ipaddress.IPv4Address):
         # use the ORM to update the deets for the corresponding hoster
         gcip = GreencheckIp(
             active=True,
@@ -107,7 +107,7 @@ def ip_ranges_for_hoster(ip_ranges, ip_version="ipv4"):
         return ips_for_hoster
 
 
-def update_hoster(self, hoster: Hostingprovider, ip_range: IPv4Address):
+def update_hoster(self, hoster: Hostingprovider, ip_range: ipaddress.IPv4Address):
         first, last = ip_range[0], ip_range[-1]
         # use the ORM to update the deets for the corresponding hoster
         return GreencheckIp.update_or_create(

--- a/apps/greencheck/management/commands/update_aws_ip_ranges.py
+++ b/apps/greencheck/management/commands/update_aws_ip_ranges.py
@@ -31,17 +31,16 @@ class AmazonCloudProvider:
             ('Amazon Montreal', 'ca-central-1', 700),
         )
 
-    def update_ranges(self):
+    def update_ranges(self, ip_ranges):
 
-        iprs = self.fetch_ip_ranges()
         res = []
 
         for region in self.green_regions:
             _, aws_code, host_id = region
 
             # pull out the ip ranges as strings
-            green_ipv4s = self.pullout_green_regions(iprs, aws_code)
-            green_ipv6s = self.pullout_green_regions(iprs, aws_code, ip_version="ipv6")
+            green_ipv4s = self.pullout_green_regions(ip_ranges, aws_code)
+            green_ipv6s = self.pullout_green_regions(ip_ranges, aws_code, ip_version="ipv6")
 
             hoster = Hostingprovider.objects.get(pk=host_id)
 

--- a/apps/greencheck/management/commands/update_aws_ip_ranges.py
+++ b/apps/greencheck/management/commands/update_aws_ip_ranges.py
@@ -25,6 +25,8 @@ class AmazonCloudProvider:
         else:
             self.green_regions = GREEN_REGIONS
 
+        logger.info(f"Instantiated with {len(self.green_regions)} region(s) to update")
+
     def update_ranges(self, ip_ranges):
 
         res = []

--- a/apps/greencheck/models.py
+++ b/apps/greencheck/models.py
@@ -99,6 +99,16 @@ class IpAddressField(Field):
             return value
         return str(ipaddress.ip_address(int(value)))
 
+    def db_type(self, connection):
+        if connection.settings_dict['ENGINE'] == 'django.db.backends.mysql':
+            # the current type in the mysql database is DECIMAL
+            # use that for compatiability
+            return "DECIMAL"
+        else:
+            # TODO check what the postgres equiv is 
+            return "DECIMAL"
+
+
     def formfield(self, form_class=None, choices_form_class=None, **kwargs):
         """Return a django.forms.Field instance for this field."""
         defaults = {
@@ -130,7 +140,6 @@ class GreencheckIp(TimeStampedModel):
         return f'{self.ip_start} - {self.ip_end}'
 
     class Meta:
-        # managed = False
         db_table = 'greencheck_ip'
         indexes = [
             models.Index(fields=['ip_end'], name='ip_eind'),

--- a/apps/greencheck/models.py
+++ b/apps/greencheck/models.py
@@ -99,15 +99,8 @@ class IpAddressField(Field):
             return value
         return str(ipaddress.ip_address(int(value)))
 
-    def db_type(self, connection):
-        if connection.settings_dict['ENGINE'] == 'django.db.backends.mysql':
-            # the current type in the mysql database is DECIMAL
-            # use that for compatiability
-            return "DECIMAL"
-        else:
-            # TODO check what the postgres equiv is 
-            return "DECIMAL"
-
+    def get_internal_type(self):
+        return "DecimalField"
 
     def formfield(self, form_class=None, choices_form_class=None, **kwargs):
         """Return a django.forms.Field instance for this field."""

--- a/apps/greencheck/test_aws_cloud_importer.py
+++ b/apps/greencheck/test_aws_cloud_importer.py
@@ -93,7 +93,7 @@ class TestAWSCLoudImporter:
         assert(GreencheckIp.objects.all().count() == 0)
         hosting_provider.save()
 
-        res, *rest = aws_cloud_provider.update_ranges(aws_cloud_provider.fetch_ip_ranges())
+        res, *rest = aws_cloud_provider.update_ranges(aws_json_ip_ranges)
         ipv4s = res['ipv4']
         ipv6s = res['ipv6']
 
@@ -106,6 +106,10 @@ class TestAWSCLoudImporter:
 
 @pytest.mark.django_db
 class TestAWSImportCommand:
+    """
+    This just tests that we have a management command that can run.
+    We _could_ mock the call to fetch ip ranges, if this turns out to be a slow test.
+    """
 
     def test_handle(self, aws_cloud_provider):
         out = StringIO()

--- a/apps/greencheck/test_aws_cloud_importer.py
+++ b/apps/greencheck/test_aws_cloud_importer.py
@@ -24,7 +24,8 @@ def hosting_provider():
 
 @pytest.fixture
 def aws_cloud_provider(hosting_provider):
-    return update_aws_ip_ranges.AmazonCloudProvider((
+    hosting_provider.save()
+    return update_aws_ip_ranges.AmazonCloudProvider(green_regions=(
         ('Amazon US West', 'us-west-2', hosting_provider.id),
     ))
 
@@ -66,6 +67,16 @@ class TestAWSCLoudImporter:
 
         hosting_provider.save()
 
+        # create one new green IP range
         aws_cloud_provider.update_hoster(hosting_provider, ip_start, ip_end)
+
+        assert(GreencheckIp.objects.all().count() == 1)
+
+    @pytest.mark.django_db
+    def test_range(self, hosting_provider, aws_cloud_provider):
+        assert(GreencheckIp.objects.all().count() == 0)
+        hosting_provider.save()
+
+        res = aws_cloud_provider.update_ranges()
 
         assert(GreencheckIp.objects.all().count() > 0)

--- a/apps/greencheck/test_aws_cloud_importer.py
+++ b/apps/greencheck/test_aws_cloud_importer.py
@@ -89,11 +89,11 @@ class TestAWSCLoudImporter:
 
         assert(GreencheckIp.objects.all().count() == 1)
 
-    def test_range(self, hosting_provider, aws_cloud_provider, aws_json_ip_ranges):
+    def test_update_range(self, hosting_provider, aws_cloud_provider, aws_json_ip_ranges):
         assert(GreencheckIp.objects.all().count() == 0)
         hosting_provider.save()
 
-        res = aws_cloud_provider.update_ranges(aws_cloud_provider.fetch_ip_ranges())
+        res, *rest = aws_cloud_provider.update_ranges(aws_cloud_provider.fetch_ip_ranges())
         ipv4s = res['ipv4']
         ipv6s = res['ipv6']
 

--- a/apps/greencheck/test_aws_cloud_importer.py
+++ b/apps/greencheck/test_aws_cloud_importer.py
@@ -78,5 +78,12 @@ class TestAWSCLoudImporter:
         hosting_provider.save()
 
         res = aws_cloud_provider.update_ranges()
+        ipv4s = res['ipv4']
+        ipv6s = res['ipv6']
 
-        assert(GreencheckIp.objects.all().count() > 0)
+
+
+        assert(len(ipv4s) == 104)
+        assert(len(ipv6s) == 20)
+        # we should have 124 ipv4 ranges added
+        assert(GreencheckIp.objects.all().count() == len(ipv4s) + len(ipv6s))

--- a/apps/greencheck/test_aws_cloud_importer.py
+++ b/apps/greencheck/test_aws_cloud_importer.py
@@ -1,0 +1,40 @@
+import pytest
+
+from apps.greencheck.management.commands import update_aws_ip_ranges
+from apps.accounts.models import Hostingprovider
+
+@pytest.fixture
+def hosting_provider():
+
+    return Hostingprovider(
+        archived= False,
+        country= 'US',
+        customer= False,
+        icon= '',
+        iconurl= '',
+        model= 'groeneenergie',
+        name= 'Amazon US West',
+        partner= '',
+        showonwebsite= True,
+        website= 'http://aws.amazon.com'
+    )
+
+@pytest.fixture
+def aws_cloud_provider(hosting_provider):
+    return update_aws_ip_ranges.AmazonCloudProvider((
+        ('Amazon US West', 'us-west-2', hosting_provider.id),
+    ))
+
+class TestAWSCLoudImporter:
+
+    @pytest.mark.django_db
+    def test_fetch_ip(self, hosting_provider, aws_cloud_provider):
+        """
+        Do we fetch the data from AWS?
+        """
+        hosting_provider.save()
+        res = aws_cloud_provider.fetch_ip_ranges()
+
+        assert(len(res.keys()) == 4 )
+
+    

--- a/apps/greencheck/test_aws_cloud_importer.py
+++ b/apps/greencheck/test_aws_cloud_importer.py
@@ -77,13 +77,12 @@ class TestAWSCLoudImporter:
         assert(GreencheckIp.objects.all().count() == 0)
         hosting_provider.save()
 
-        res = aws_cloud_provider.update_ranges()
+        res = aws_cloud_provider.update_ranges(aws_cloud_provider.fetch_ip_ranges())
         ipv4s = res['ipv4']
         ipv6s = res['ipv6']
 
 
-
         assert(len(ipv4s) == 104)
         assert(len(ipv6s) == 20)
-        # we should have 124 ipv4 ranges added
+        # we should have 124 ranges in total
         assert(GreencheckIp.objects.all().count() == len(ipv4s) + len(ipv6s))

--- a/apps/greencheck/test_aws_cloud_importer.py
+++ b/apps/greencheck/test_aws_cloud_importer.py
@@ -1,6 +1,7 @@
 import pytest
-
+import pathlib
 import ipaddress
+import json
 
 from apps.greencheck.management.commands import update_aws_ip_ranges
 from apps.accounts.models import Hostingprovider
@@ -28,6 +29,15 @@ def aws_cloud_provider(hosting_provider):
     return update_aws_ip_ranges.AmazonCloudProvider(green_regions=(
         ('Amazon US West', 'us-west-2', hosting_provider.id),
     ))
+
+@pytest.fixture
+def aws_json_ip_ranges():
+    this_file = pathlib.Path(__file__)
+    json_path = this_file.parent.joinpath('fixtures', "ip_ranges.json")
+    with open(json_path) as ipr:
+        ip_ranges = json.loads(ipr.read())
+        return ip_ranges
+
 
 class TestAWSCLoudImporter:
 
@@ -73,7 +83,7 @@ class TestAWSCLoudImporter:
         assert(GreencheckIp.objects.all().count() == 1)
 
     @pytest.mark.django_db
-    def test_range(self, hosting_provider, aws_cloud_provider):
+    def test_range(self, hosting_provider, aws_cloud_provider, aws_json_ip_ranges):
         assert(GreencheckIp.objects.all().count() == 0)
         hosting_provider.save()
 

--- a/apps/greencheck/test_aws_cloud_importer.py
+++ b/apps/greencheck/test_aws_cloud_importer.py
@@ -42,12 +42,12 @@ class TestAWSCLoudImporter:
 
 
     @pytest.mark.django_db
-    def test_pullout_green_ips(self, hosting_provider, aws_cloud_provider):
+    def pullout_green_regions(self, hosting_provider, aws_cloud_provider):
         res = aws_cloud_provider.fetch_ip_ranges()
 
         _, region, host_id = aws_cloud_provider.green_regions[0]
 
-        iprs = aws_cloud_provider.pullout_green_ips(res, region)
+        iprs = aws_cloud_provider.pullout_green_regions(res, region)
 
         ip_ranges = aws_cloud_provider.ip_ranges_for_hoster(iprs)
 
@@ -58,7 +58,7 @@ class TestAWSCLoudImporter:
 
         res = aws_cloud_provider.fetch_ip_ranges()
         _, region, host_id = aws_cloud_provider.green_regions[0]
-        iprs = aws_cloud_provider.pullout_green_ips(res, region)
+        iprs = aws_cloud_provider.pullout_green_regions(res, region)
         ip_ranges = aws_cloud_provider.ip_ranges_for_hoster(iprs)
 
         ip_start, ip_end = ip_ranges[0][0], ip_ranges[0][-1]

--- a/apps/greencheck/test_models.py
+++ b/apps/greencheck/test_models.py
@@ -8,8 +8,8 @@ from apps.greencheck.models import GreencheckIp
 class TestGreenCheckIP:
 
     def test_greencheckip_has_start_and_end(self, hosting_provider, db):
-
-        gcip = GreencheckIp.objects.update_or_create(
+        hosting_provider.save()
+        gcip = GreencheckIp.objects.create(
             active=True,
             ip_start="127.0.0.1",
             ip_end="120.0.0.1",

--- a/apps/greencheck/test_models.py
+++ b/apps/greencheck/test_models.py
@@ -1,0 +1,19 @@
+import pytest
+
+import ipaddress
+
+from apps.greencheck.models import GreencheckIp
+
+
+class TestGreenCheckIP:
+
+    def test_greencheckip_has_start_and_end(self, hosting_provider, db):
+
+        gcip = GreencheckIp.objects.update_or_create(
+            active=True,
+            ip_start="127.0.0.1",
+            ip_end="120.0.0.1",
+            hostingprovider=hosting_provider
+        )
+        gcip.save()
+

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,26 @@
+import pytest
+
+from apps.accounts.models import Hostingprovider
+from apps.greencheck.models import GreencheckIp
+
+@pytest.fixture
+def hosting_provider():
+
+    return Hostingprovider(
+        archived= False,
+        country= 'US',
+        customer= False,
+        icon= '',
+        iconurl= '',
+        model= 'groeneenergie',
+        name= 'Amazon US West',
+        partner= '',
+        showonwebsite= True,
+        website= 'http://aws.amazon.com'
+    )
+
+@pytest.fixture
+def aws_cloud_provider(hosting_provider):
+    return update_aws_ip_ranges.AmazonCloudProvider((
+        ('Amazon US West', 'us-west-2', hosting_provider.id),
+    ))

--- a/greenweb/settings/testing.py
+++ b/greenweb/settings/testing.py
@@ -1,0 +1,5 @@
+import socket
+from .common import * # noqa
+
+INTERNAL_IPS = ['127.0.0.1']
+ALLOWED_HOSTS.extend(['127.0.0.1', 'localhost'])

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+DJANGO_SETTINGS_MODULE=greenweb.settings.testing
+addopts = --reuse-db --nomigrations --maxfail=1
+python_files = tests.py test_*.py *_tests.py

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+pipenv run pytest


### PR DESCRIPTION
This PR adds a few things

### Add tests with pytest

We now have a test harness for future development. I needed this to catch a hard to diagnose bug with the new IpAddress field implemented earlier.


### Add an management command for importing AWS public IP ranges

We also have management command to run imports from public listings of IP ranges, as listed in issue 18 on the green web foundation.

https://github.com/thegreenwebfoundation/thegreenwebfoundation/issues/18

This updates the 5 regions listed as green/sustainable by Amazon, and imports their IPs.

### Things to bear in mind before we deploy this and run the import

*Overlapping IP ranges now that we have data direct from AWS* - We've seen bugs already where the API has been expecting just a single response back, when checking if a domain has an IP inside a given IP address. You can see this documented in issue 48 on the TGWF repo as described below:

https://github.com/thegreenwebfoundation/thegreenwebfoundation/issues/48

If this is the case, we'll need to account for this before we merge it, otherwise we might trigger a bunch of 500's.

@arendjantetteroo - I know that before running this import, some people who are already customers of Amazon, have listed their IP ranges with us. This means we'd end up with two hosters being listed. How do we handle cases when we have multiple hosters returned?